### PR TITLE
Add hamburger aria attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
         </span>
         <span class="logo-text">BR-English</span>
       </a>
-      <button class="hamburger" id="hamburger" aria-label="Abrir menu">
+      <button class="hamburger" id="hamburger" aria-label="Abrir menu" aria-controls="menu" aria-expanded="false">
         <span></span><span></span><span></span>
       </button>
       <ul class="menu" id="menu">

--- a/script.js
+++ b/script.js
@@ -22,6 +22,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const hamb = document.getElementById('hamburger');
   const menu = document.getElementById('menu');
   hamb.addEventListener('click', () => {
+    const expanded = hamb.getAttribute('aria-expanded') === 'true';
+    hamb.setAttribute('aria-expanded', String(!expanded));
     menu.classList.toggle('open');
   });
 


### PR DESCRIPTION
## Summary
- set initial `aria-expanded` and `aria-controls` on the hamburger menu button
- toggle the `aria-expanded` state when opening or closing the menu

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_684b3e803a788323b8a45c2cb25fa4a8