### PR TITLE
Add dropdowns for Vocabulary, Listening and Reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ O **BR-English** oferece:
 
 - **Modo escuro** moderno, inspirado em layouts minimalistas para conforto visual.  
 - **Menu de navegação** com itens “Grammar”, “Vocabulary”, “Listening” e “Reading”.  
-- **Dropdown de níveis** em “Grammar”: A1, A2, B1, B1+ e B2, cada um com ícone circular colorido.  
+- **Dropdown de níveis** em “Grammar”, “Vocabulary”, “Listening” e “Reading”: A1, A2, B1, B1+ e B2, cada um com ícone circular colorido.
 - **Responsividade**: menu “hamburger” para dispositivos móveis.  
 - **Acessibilidade**: botão flutuante de alto contraste.  
 - **Seção hero centralizada** com título e subtítulo posicionados verticalmente no centro da viewport.

--- a/index.html
+++ b/index.html
@@ -55,9 +55,102 @@
             </li>
           </ul>
         </li>
-        <li class="menu-item"><a href="#">Vocabulary</a></li>
-        <li class="menu-item"><a href="#">Listening</a></li>
-        <li class="menu-item"><a href="#">Reading</a></li>
+        <li class="menu-item has-dropdown">
+          <button class="dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+            Vocabulary
+          </button>
+          <ul class="dropdown" role="menu">
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a1">A1</span> Elementary
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a2">A2</span> Pre-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1">B1</span> Intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1plus">B1+</span> Upper-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b2">B2</span> Pre-advanced
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li class="menu-item has-dropdown">
+          <button class="dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+            Listening
+          </button>
+          <ul class="dropdown" role="menu">
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a1">A1</span> Elementary
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a2">A2</span> Pre-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1">B1</span> Intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1plus">B1+</span> Upper-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b2">B2</span> Pre-advanced
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li class="menu-item has-dropdown">
+          <button class="dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+            Reading
+          </button>
+          <ul class="dropdown" role="menu">
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a1">A1</span> Elementary
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a2">A2</span> Pre-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1">B1</span> Intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1plus">B1+</span> Upper-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b2">B2</span> Pre-advanced
+              </a>
+            </li>
+          </ul>
+        </li>
       </ul>
     </nav>
   </header>


### PR DESCRIPTION
## Summary
- add dropdown menus for Vocabulary, Listening and Reading
- document the new dropdowns in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684b478d1e708323a9bfe54398dda8c5