### PR TITLE
Add A1 grammar lesson pages

### DIFF
--- a/grammar/a1-elementary/demonstratives.html
+++ b/grammar/a1-elementary/demonstratives.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="BR-English is a responsive site with grammar, vocabulary, listening and reading resources from levels A1 to B2." />
+  <title>This, that, these, those</title>
+  <link rel="stylesheet" href="../../style.css" />
+</head>
+<body>
+  <header>
+    <nav class="navbar">
+      <a href="#" class="logo">
+        <span class="logo-icon">
+          <span class="bar green"></span>
+          <span class="bar yellow"></span>
+          <span class="bar blue"></span>
+        </span>
+        <span class="logo-text">BR-English</span>
+      </a>
+      <button class="hamburger" id="hamburger" aria-label="Abrir menu" aria-controls="menu" aria-expanded="false">
+        <span></span><span></span><span></span>
+      </button>
+      <ul class="menu" id="menu">
+        <li class="menu-item has-dropdown">
+          <button class="dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+            Grammar
+          </button>
+          <ul class="dropdown" role="menu">
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a1">A1</span> Elementary
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a2">A2</span> Pre-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1">B1</span> Intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1plus">B1+</span> Upper-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b2">B2</span> Pre-advanced
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li class="menu-item has-dropdown">
+          <button class="dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+            Vocabulary
+          </button>
+          <ul class="dropdown" role="menu">
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a1">A1</span> Elementary
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a2">A2</span> Pre-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1">B1</span> Intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1plus">B1+</span> Upper-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b2">B2</span> Pre-advanced
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li class="menu-item has-dropdown">
+          <button class="dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+            Listening
+          </button>
+          <ul class="dropdown" role="menu">
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a1">A1</span> Elementary
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a2">A2</span> Pre-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1">B1</span> Intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1plus">B1+</span> Upper-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b2">B2</span> Pre-advanced
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li class="menu-item has-dropdown">
+          <button class="dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+            Reading
+          </button>
+          <ul class="dropdown" role="menu">
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a1">A1</span> Elementary
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a2">A2</span> Pre-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1">B1</span> Intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1plus">B1+</span> Upper-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b2">B2</span> Pre-advanced
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+  </header>
+
+  <main class="hero">
+    <h1>This, that, these, those</h1>
+    <div class="tabs">
+      <button class="tab-button active" data-tab="explanation">Explanation</button>
+      <button class="tab-button" data-tab="exercises">Exercises</button>
+    </div>
+    <section id="explanation" class="tab-content active">
+      <p>Use <strong>this</strong> e <strong>that</strong> para o singular, e <strong>these</strong> e <strong>those</strong> para o plural.</p>
+    </section>
+    <section id="exercises" class="tab-content">
+      <p>Exercícios em breve.</p>
+    </section>
+  </main>
+
+  <footer>
+    © 2025 BR-English. Todos os direitos reservados.
+  </footer>
+
+  <script src="../../script.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const buttons = document.querySelectorAll('.tab-button');
+      const contents = document.querySelectorAll('.tab-content');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          buttons.forEach(b => b.classList.remove('active'));
+          contents.forEach(c => c.classList.remove('active'));
+          btn.classList.add('active');
+          document.getElementById(btn.dataset.tab).classList.add('active');
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/grammar/a1-elementary/index.html
+++ b/grammar/a1-elementary/index.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="BR-English is a responsive site with grammar, vocabulary, listening and reading resources from levels A1 to B2." />
+  <title>A1 Grammar Lessons and Exercises</title>
+  <link rel="stylesheet" href="../../style.css" />
+</head>
+<body>
+  <header>
+    <nav class="navbar">
+      <a href="#" class="logo">
+        <span class="logo-icon">
+          <span class="bar green"></span>
+          <span class="bar yellow"></span>
+          <span class="bar blue"></span>
+        </span>
+        <span class="logo-text">BR-English</span>
+      </a>
+      <button class="hamburger" id="hamburger" aria-label="Abrir menu" aria-controls="menu" aria-expanded="false">
+        <span></span><span></span><span></span>
+      </button>
+      <ul class="menu" id="menu">
+        <li class="menu-item has-dropdown">
+          <button class="dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+            Grammar
+          </button>
+          <ul class="dropdown" role="menu">
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a1">A1</span> Elementary
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a2">A2</span> Pre-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1">B1</span> Intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1plus">B1+</span> Upper-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b2">B2</span> Pre-advanced
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li class="menu-item has-dropdown">
+          <button class="dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+            Vocabulary
+          </button>
+          <ul class="dropdown" role="menu">
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a1">A1</span> Elementary
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a2">A2</span> Pre-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1">B1</span> Intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1plus">B1+</span> Upper-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b2">B2</span> Pre-advanced
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li class="menu-item has-dropdown">
+          <button class="dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+            Listening
+          </button>
+          <ul class="dropdown" role="menu">
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a1">A1</span> Elementary
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a2">A2</span> Pre-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1">B1</span> Intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1plus">B1+</span> Upper-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b2">B2</span> Pre-advanced
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li class="menu-item has-dropdown">
+          <button class="dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+            Reading
+          </button>
+          <ul class="dropdown" role="menu">
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a1">A1</span> Elementary
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a2">A2</span> Pre-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1">B1</span> Intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1plus">B1+</span> Upper-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b2">B2</span> Pre-advanced
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+  </header>
+
+  <main class="hero">
+    <h1>A1 Grammar Lessons and Exercises</h1>
+    <p>Escolha um tópico para começar:</p>
+    <ul class="lesson-links">
+      <li><a href="to-be.html">Formas simples do verbo to be (am/is/are)</a></li>
+      <li><a href="demonstratives.html">This, that, these, those</a></li>
+      <li><a href="possessives-and-pronouns.html">Adjetivos possessivos e pronomes pessoais</a></li>
+    </ul>
+  </main>
+
+  <footer>
+    © 2025 BR-English. Todos os direitos reservados.
+  </footer>
+
+  <script src="../../script.js"></script>
+</body>
+</html>

--- a/grammar/a1-elementary/possessives-and-pronouns.html
+++ b/grammar/a1-elementary/possessives-and-pronouns.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="BR-English is a responsive site with grammar, vocabulary, listening and reading resources from levels A1 to B2." />
+  <title>Adjetivos possessivos e pronomes pessoais</title>
+  <link rel="stylesheet" href="../../style.css" />
+</head>
+<body>
+  <header>
+    <nav class="navbar">
+      <a href="#" class="logo">
+        <span class="logo-icon">
+          <span class="bar green"></span>
+          <span class="bar yellow"></span>
+          <span class="bar blue"></span>
+        </span>
+        <span class="logo-text">BR-English</span>
+      </a>
+      <button class="hamburger" id="hamburger" aria-label="Abrir menu" aria-controls="menu" aria-expanded="false">
+        <span></span><span></span><span></span>
+      </button>
+      <ul class="menu" id="menu">
+        <li class="menu-item has-dropdown">
+          <button class="dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+            Grammar
+          </button>
+          <ul class="dropdown" role="menu">
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a1">A1</span> Elementary
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a2">A2</span> Pre-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1">B1</span> Intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1plus">B1+</span> Upper-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b2">B2</span> Pre-advanced
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li class="menu-item has-dropdown">
+          <button class="dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+            Vocabulary
+          </button>
+          <ul class="dropdown" role="menu">
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a1">A1</span> Elementary
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a2">A2</span> Pre-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1">B1</span> Intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1plus">B1+</span> Upper-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b2">B2</span> Pre-advanced
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li class="menu-item has-dropdown">
+          <button class="dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+            Listening
+          </button>
+          <ul class="dropdown" role="menu">
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a1">A1</span> Elementary
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a2">A2</span> Pre-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1">B1</span> Intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1plus">B1+</span> Upper-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b2">B2</span> Pre-advanced
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li class="menu-item has-dropdown">
+          <button class="dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+            Reading
+          </button>
+          <ul class="dropdown" role="menu">
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a1">A1</span> Elementary
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a2">A2</span> Pre-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1">B1</span> Intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1plus">B1+</span> Upper-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b2">B2</span> Pre-advanced
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+  </header>
+
+  <main class="hero">
+    <h1>Adjetivos possessivos e pronomes pessoais</h1>
+    <div class="tabs">
+      <button class="tab-button active" data-tab="explanation">Explanation</button>
+      <button class="tab-button" data-tab="exercises">Exercises</button>
+    </div>
+    <section id="explanation" class="tab-content active">
+      <p>Combine os pronomes pessoais (I, you, he, etc.) com os adjetivos possessivos correspondentes (my, your, his, etc.).</p>
+    </section>
+    <section id="exercises" class="tab-content">
+      <p>Exercícios em breve.</p>
+    </section>
+  </main>
+
+  <footer>
+    © 2025 BR-English. Todos os direitos reservados.
+  </footer>
+
+  <script src="../../script.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const buttons = document.querySelectorAll('.tab-button');
+      const contents = document.querySelectorAll('.tab-content');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          buttons.forEach(b => b.classList.remove('active'));
+          contents.forEach(c => c.classList.remove('active'));
+          btn.classList.add('active');
+          document.getElementById(btn.dataset.tab).classList.add('active');
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/grammar/a1-elementary/to-be.html
+++ b/grammar/a1-elementary/to-be.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="BR-English is a responsive site with grammar, vocabulary, listening and reading resources from levels A1 to B2." />
+  <title>Formas simples do verbo to be</title>
+  <link rel="stylesheet" href="../../style.css" />
+</head>
+<body>
+  <header>
+    <nav class="navbar">
+      <a href="#" class="logo">
+        <span class="logo-icon">
+          <span class="bar green"></span>
+          <span class="bar yellow"></span>
+          <span class="bar blue"></span>
+        </span>
+        <span class="logo-text">BR-English</span>
+      </a>
+      <button class="hamburger" id="hamburger" aria-label="Abrir menu" aria-controls="menu" aria-expanded="false">
+        <span></span><span></span><span></span>
+      </button>
+      <ul class="menu" id="menu">
+        <li class="menu-item has-dropdown">
+          <button class="dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+            Grammar
+          </button>
+          <ul class="dropdown" role="menu">
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a1">A1</span> Elementary
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a2">A2</span> Pre-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1">B1</span> Intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1plus">B1+</span> Upper-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b2">B2</span> Pre-advanced
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li class="menu-item has-dropdown">
+          <button class="dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+            Vocabulary
+          </button>
+          <ul class="dropdown" role="menu">
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a1">A1</span> Elementary
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a2">A2</span> Pre-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1">B1</span> Intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1plus">B1+</span> Upper-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b2">B2</span> Pre-advanced
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li class="menu-item has-dropdown">
+          <button class="dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+            Listening
+          </button>
+          <ul class="dropdown" role="menu">
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a1">A1</span> Elementary
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a2">A2</span> Pre-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1">B1</span> Intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1plus">B1+</span> Upper-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b2">B2</span> Pre-advanced
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li class="menu-item has-dropdown">
+          <button class="dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+            Reading
+          </button>
+          <ul class="dropdown" role="menu">
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a1">A1</span> Elementary
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-a2">A2</span> Pre-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1">B1</span> Intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b1plus">B1+</span> Upper-intermediate
+              </a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="#">
+                <span class="level-circle level-b2">B2</span> Pre-advanced
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+  </header>
+
+  <main class="hero">
+    <h1>Formas simples do verbo to be</h1>
+    <div class="tabs">
+      <button class="tab-button active" data-tab="explanation">Explanation</button>
+      <button class="tab-button" data-tab="exercises">Exercises</button>
+    </div>
+    <section id="explanation" class="tab-content active">
+      <p>Use <strong>am</strong> com I, <strong>is</strong> com he/she/it e <strong>are</strong> com you/we/they.</p>
+    </section>
+    <section id="exercises" class="tab-content">
+      <p>Exercícios em breve.</p>
+    </section>
+  </main>
+
+  <footer>
+    © 2025 BR-English. Todos os direitos reservados.
+  </footer>
+
+  <script src="../../script.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const buttons = document.querySelectorAll('.tab-button');
+      const contents = document.querySelectorAll('.tab-content');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          buttons.forEach(b => b.classList.remove('active'));
+          contents.forEach(c => c.classList.remove('active'));
+          btn.classList.add('active');
+          document.getElementById(btn.dataset.tab).classList.add('active');
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -144,6 +144,42 @@ body {
   margin-left: auto;
   margin-right: auto;
 }
+.lesson-links {
+  list-style: none;
+  margin-top: 24px;
+}
+.lesson-links li {
+  margin: 8px 0;
+}
+.lesson-links a {
+  color: #3478f6;
+  text-decoration: underline;
+}
+.tabs {
+  margin-top: 24px;
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+}
+.tab-button {
+  background: none;
+  border: 1px solid #3478f6;
+  color: #3478f6;
+  padding: 8px 16px;
+  cursor: pointer;
+  border-radius: 4px;
+}
+.tab-button.active {
+  background: #3478f6;
+  color: #fff;
+}
+.tab-content {
+  display: none;
+  margin-top: 20px;
+}
+.tab-content.active {
+  display: block;
+}
 
 /* ==== FOOTER ==== */
 footer {


### PR DESCRIPTION
## Summary
- add new subdirectory for A1 Elementary grammar
- create index page listing A1 grammar lessons
- add three lesson pages with Explanation/Exercises tabs
- extend CSS for lesson links and tabbed interface

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b4dcea4c88323b00ec492936bc33d