### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/script.js
+++ b/script.js
@@ -25,6 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const expanded = hamb.getAttribute('aria-expanded') === 'true';
     hamb.setAttribute('aria-expanded', String(!expanded));
     menu.classList.toggle('open');
+    hamb.classList.toggle('open');
   });
 
 });

--- a/style.css
+++ b/style.css
@@ -71,6 +71,17 @@ body {
   width: 24px;
   height: 2px;
   background: #fff;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.hamburger.open span:nth-child(1) {
+  transform: translateY(7px) rotate(45deg);
+}
+.hamburger.open span:nth-child(2) {
+  opacity: 0;
+}
+.hamburger.open span:nth-child(3) {
+  transform: translateY(-7px) rotate(-45deg);
 }
 
 /* ==== DROPDOWN ==== */
@@ -125,7 +136,7 @@ body {
 
 /* ==== HERO ==== */
 .hero {
-  min-height: 100vh;      /* <<< preenche 100% da altura da janela */
+  min-height: 100svh;      /* preenche 100% da altura em dispositivos moveis */
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -133,7 +144,7 @@ body {
   padding: 0 20px;
 }
 .hero h1 {
-  font-size: 3rem;
+  font-size: clamp(2rem, 5vw, 3rem);
   font-weight: 700;
 }
 .hero p {
@@ -212,12 +223,22 @@ footer {
   .menu.open {
     position: absolute;
     top: 60px;
+    left: 0;
     right: 0;
     background: #121212;
     flex-direction: column;
-    width: 200px;
-    padding: 16px;
+    width: 100%;
+    padding: 24px;
     display: flex;
-    gap: 16px;
+    gap: 20px;
+    transition: transform 0.3s ease;
   }
+  .menu.open > li {
+    padding: 12px 0;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero h1 { font-size: 2rem; }
+  .hero p { font-size: 1rem; }
 }


### PR DESCRIPTION
## Summary
- make hero height use `100svh` and clamp heading size
- animate hamburger to an X
- widen and pad mobile menu and menu items
- adjust fonts for very small screens
- toggle open class on hamburger button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c16ce04c0832398bed20bef3fa271