### PR TITLE
Fix dropdown overlay on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -236,6 +236,15 @@ footer {
   .menu.open > li {
     padding: 12px 0;
   }
+  /* Dropdowns ocupam espaco em vez de sobrepor itens */
+  .has-dropdown { position: static; }
+  .has-dropdown .dropdown {
+    position: static;
+    min-width: 0;
+    width: 100%;
+    box-shadow: none;
+    margin-top: 8px;
+  }
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- prevent dropdown menu from overlapping buttons on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c21e7a3e88323a765fd65c8a254a4