### PR TITLE
Add dark mode example block

### DIFF
--- a/grammar/a1-elementary/to-be.html
+++ b/grammar/a1-elementary/to-be.html
@@ -264,13 +264,15 @@
         <p>❌ A: Are you happy? B: Yes, I’m.<br />✅ A: Are you happy? B: Yes, I am.</p>
 
         <h3>3. Using the verb to be</h3>
-        <p>The present simple of the verb <em>be</em> has three forms:</p>
-        <ul>
-          <li>I am.</li>
-          <li>He/She/It is.</li>
-          <li>We/You/They are.</li>
-        </ul>
-        <p><strong>They</strong> = people and things</p>
+        <h4 class="example-title">The present simple of the verb be has three forms</h4>
+        <div class="example-box">
+          <ul class="example-list">
+            <li>I am.</li>
+            <li>He/She/It is.</li>
+            <li>We/You/They are.</li>
+          </ul>
+        </div>
+        <p class="example-caption"><strong>They</strong> = people and things</p>
         <p>We use <strong>he</strong> for a man, <strong>she</strong> for a woman, and <strong>it</strong> for a thing.</p>
         <p>He‘s a little boy.<br />She‘s beautiful.<br />I like this TV. It‘s very big.</p>
         <p>We use <strong>they</strong> for people and for things.</p>

--- a/style.css
+++ b/style.css
@@ -208,6 +208,34 @@ table.simple-table th {
   background: rgba(255, 255, 255, 0.1);
 }
 
+/* ==== EXAMPLE BLOCK ==== */
+.example-title {
+  text-align: center;
+  margin-top: 16px;
+}
+
+.example-box {
+  background: #000;
+  border-left: 4px solid #e0e0e0;
+  padding: 16px;
+  margin-top: 8px;
+}
+
+.example-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.example-caption {
+  text-align: center;
+  margin-top: 8px;
+}
+
 /* ==== FOOTER ==== */
 footer {
   text-align: center;


### PR DESCRIPTION
## Summary
- add example block styles for dark mode
- display "The present simple of the verb be" list in a dark block on *to-be.html*

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684cbb232fa08323b72e1e7dde680171