### PR TITLE
Fix inconsistent heading sizes in "to be" lesson

### DIFF
--- a/grammar/a1-elementary/to-be.html
+++ b/grammar/a1-elementary/to-be.html
@@ -294,7 +294,7 @@
         </div>
 
         <div class="note-box">
-          <h5>Don’t forget the subject</h5>
+          <h4>Don’t forget the subject</h4>
           <p>We always need a subject before the verb.</p>
           <div class="example-container">
             <p>It is cold.<span class="correct"></span><br />Is cold.<span class="incorrect"></span></p>
@@ -302,7 +302,7 @@
           </div>
         </div>
 
-        <h5 class="section-subtitle">Contractions or short forms</h5>
+        <h4 class="section-subtitle">Contractions or short forms</h4>
         <p>We use <strong>'m</strong>, <strong>'s</strong> and <strong>'re</strong> with personal pronouns (I, you, he, etc.)</p>
         <div class="example-container">
           <p>I'm sad.<span class="correct"></span></p>
@@ -315,7 +315,7 @@
           <p>London's an expensive city.<span class="correct"></span></p>
         </div>
 
-        <h5 class="section-subtitle">Contractions in short answers</h5>
+        <h4 class="section-subtitle">Contractions in short answers</h4>
         <p>We can only use contractions in negative short answers. Not in positive short answers.</p>
         <div class="example-container">
           <p>Yes, I am.<span class="correct"></span> Yes, I'm.<span class="incorrect"></span></p>

--- a/style.css
+++ b/style.css
@@ -307,6 +307,7 @@ footer {
 .section-subtitle {
   color: #00bcd4;
   font-weight: 700;
+  font-size: 1.5rem;
   margin-top: 24px;
   margin-bottom: 8px;
   text-align: left;
@@ -342,7 +343,7 @@ footer {
   margin: 20px 0;
   color: #ccc;
 }
-.note-box h5 {
+.note-box h4 {
   color: #00bcd4;
   margin-top: 0;
   font-weight: 700;


### PR DESCRIPTION
## Summary
- ensure heading size consistency in the *to-be* grammar page
- apply updated CSS rules for note boxes and section subtitles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e2be246f083238e11d103da033655