### PR TITLE
Fix inconsistent heading sizes

### DIFF
--- a/style.css
+++ b/style.css
@@ -292,6 +292,7 @@ footer {
   margin-top: 24px;
   margin-bottom: 8px;
   text-align: left;
+  font-size: 1rem;
 }
 .forms-box {
   background: #222;
@@ -307,7 +308,7 @@ footer {
 .section-subtitle {
   color: #00bcd4;
   font-weight: 700;
-  font-size: 1.5rem;
+  font-size: 1rem;
   margin-top: 24px;
   margin-bottom: 8px;
   text-align: left;
@@ -347,4 +348,5 @@ footer {
   color: #00bcd4;
   margin-top: 0;
   font-weight: 700;
+  font-size: 1rem;
 }


### PR DESCRIPTION
## Summary
- ensure `.intro-heading` text has an explicit size
- match `section-subtitle` and note titles to the same size

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684e2d4926908323954492700fe56330