### PR TITLE
Fix table layout width

### DIFF
--- a/style.css
+++ b/style.css
@@ -207,9 +207,12 @@ body {
 /* ==== TABLE ==== */
 table.simple-table {
   margin: 16px auto;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
   width: 100%;
-  max-width: 600px;
+  max-width: 800px;
+  border-radius: 8px;
+  overflow: hidden;
 }
 table.simple-table th,
 table.simple-table td {


### PR DESCRIPTION
## Summary
- adjust the width of `.simple-table` to match note boxes
- add rounded borders for tables

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684e302e444083239df2340c433f608d