### PR TITLE
Add tooltip translations

### DIFF
--- a/grammar/a1-elementary/to-be.html
+++ b/grammar/a1-elementary/to-be.html
@@ -272,25 +272,31 @@
 
         <h3>3. Using the verb to be</h3>
         <h4 class="intro-heading">The present simple of the verb be has three forms:</h4>
-        <div class="forms-box">
+          <div class="forms-box">
           <ul>
-            <li>I am.</li>
-            <li>He/She/It is.</li>
-            <li>We/You/They are.</li>
+            <li><span class="tooltip" data-pt="eu">I</span> am.</li>
+            <li>
+              <span class="tooltip" data-pt="ele">He</span>/<span class="tooltip" data-pt="ela">She</span>/<span class="tooltip" data-pt="ele/ela (para coisas ou animais)">It</span>
+              is.
+            </li>
+            <li>
+              <span class="tooltip" data-pt="nós">We</span>/<span class="tooltip" data-pt="você(s)">You</span>/<span class="tooltip" data-pt="eles/elas">They</span>
+              are.
+            </li>
           </ul>
         </div>
 
         <h4 class="section-subtitle">They = people and things</h4>
-        <p>We use <span class="highlight">he</span> for a man, <span class="highlight">she</span> for a woman, and <span class="highlight">it</span> for a thing.</p>
+        <p>We use <span class="tooltip highlight" data-pt="ele">he</span> for a man, <span class="tooltip highlight" data-pt="ela">she</span> for a woman, and <span class="tooltip highlight" data-pt="ele/ela (para coisas ou animais)">it</span> for a thing.</p>
         <div class="example-container">
-          <p>He's a little boy.<span class="correct"></span></p>
-          <p>She's beautiful.<span class="correct"></span></p>
-          <p>I like this TV. It's very big.<span class="correct"></span></p>
+          <p><span class="tooltip" data-pt="Ele é">He's</span> a <span class="tooltip" data-pt="pequeno">little</span> <span class="tooltip" data-pt="menino">boy</span>.<span class="correct"></span></p>
+          <p><span class="tooltip" data-pt="Ela é">She's</span> <span class="tooltip" data-pt="bonita">beautiful</span>.<span class="correct"></span></p>
+          <p>I like this TV. <span class="tooltip" data-pt="Ela é">It's</span> very <span class="tooltip" data-pt="grande">big</span>.<span class="correct"></span></p>
         </div>
-        <p>We use <span class="highlight">they</span> for people and for things.</p>
+        <p>We use <span class="tooltip highlight" data-pt="eles/elas">they</span> for people and for things.</p>
         <div class="example-container">
-          <p>I love Sara and Jonas. They are my friends.<span class="correct"></span></p>
-          <p>I love these chairs. They are very beautiful.<span class="correct"></span></p>
+          <p>I love Sara and Jonas. <span class="tooltip" data-pt="Eles">They</span> are my <span class="tooltip" data-pt="amigos">friends</span>.<span class="correct"></span></p>
+          <p>I love these chairs. <span class="tooltip" data-pt="Elas">They</span> are very <span class="tooltip" data-pt="bonitas">beautiful</span>.<span class="correct"></span></p>
         </div>
 
         <div class="note-box">

--- a/style.css
+++ b/style.css
@@ -365,3 +365,32 @@ footer {
   font-weight: 700;
   font-size: 1rem;
 }
+
+/* Tooltip for inline translations */
+.tooltip {
+  position: relative;
+  cursor: help;
+}
+
+.tooltip::after {
+  content: attr(data-pt);
+  position: absolute;
+  bottom: 120%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #333;
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: 4px;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s;
+  font-size: 0.8em;
+  z-index: 10;
+}
+
+.tooltip:hover::after,
+.tooltip:focus::after {
+  opacity: 1;
+}


### PR DESCRIPTION
## Summary
- add tooltip styling for translations in `style.css`
- wrap key pronouns and example words in `to-be.html` with tooltip spans

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6850b592c5188323885a7e89a0e01ef6