### PR TITLE
Fix short answers example layout

### DIFF
--- a/grammar/a1-elementary/to-be.html
+++ b/grammar/a1-elementary/to-be.html
@@ -318,9 +318,9 @@
         <h4 class="section-subtitle">Contractions in short answers</h4>
         <p>We can only use contractions in negative short answers. Not in positive short answers.</p>
         <div class="example-container">
-          <p>Yes, I am.<span class="correct"></span> Yes, I'm.<span class="incorrect"></span></p>
-          <p>Yes, she is.<span class="correct"></span> Yes, she's.<span class="incorrect"></span></p>
-          <p>Yes, they are.<span class="correct"></span> Yes, they're.<span class="incorrect"></span></p>
+          <p>Yes, I am.<span class="correct"></span><br />Yes, I'm.<span class="incorrect"></span></p>
+          <p>Yes, she is.<span class="correct"></span><br />Yes, she's.<span class="incorrect"></span></p>
+          <p>Yes, they are.<span class="correct"></span><br />Yes, they're.<span class="incorrect"></span></p>
         </div>
       </section>
       <section id="exercises" class="tab-content">


### PR DESCRIPTION
## Summary
- use line breaks in short answers block so correct/incorrect examples appear one below the other

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685448ae9e2c83238d5e563ee7810c3e