### PR TITLE
Update to-be examples tab and highlight forms

### DIFF
--- a/grammar/a1-elementary/to-be.html
+++ b/grammar/a1-elementary/to-be.html
@@ -160,7 +160,7 @@
       <h1>Formas simples do verbo to be</h1>
       <div class="tabs">
       <button class="tab-button active" data-tab="explanation">Explanation</button>
-      <button class="tab-button" data-tab="exercises">Exemplos</button>
+      <button class="tab-button" data-tab="exercises">Exemples</button>
     </div>
       <section id="explanation" class="tab-content active">
         <p>A seguir, você encontra todas as formas do verbo <em>to be</em> no presente simples, organizadas em afirmativa, negativa, interrogativa e respostas curtas.</p>
@@ -379,36 +379,36 @@
       <section id="exercises" class="tab-content">
         <h3>Present simple forms of ‘to be’: am/is/are</h3>
         <div class="example-container">
-          <p>1. Are you a teacher? Yes, I am.</p>
-          <p>2. Is your name Marcus? Yes, it is.</p>
-          <p>3. Are your children here? No, they aren't.</p>
-          <p>4. Is this your suitcase? No, it isn't.</p>
-          <p>5. Where are we? I think this is Oxford Street.</p>
-          <p>6. Is it Saturday today? No, it's Sunday.</p>
-          <p>7. Are your friends from the UK? No, they are from the US.</p>
-          <p>8. Hello, Maria. How are you? I'm fine, thanks.</p>
-          <p>9. How old is Peter? I think he is 30 years old.</p>
-          <p>10. Are David and Molly here? Yes, they're next to the door.</p>
-          <p>11. She is fantastic. She's fantastic.</p>
-          <p>12. She is a teacher. She isn't a teacher. Is she a teacher?</p>
-          <p>13. They're in Berlin. They aren't in Berlin. Are they in Berlin?</p>
-          <p>14. It's a nice day. It isn't a nice day. Is it a nice day?</p>
-          <p>15. I am very excited. I'm not very excited. Am I very excited?</p>
-          <p>16. We are students. We aren't students. Are we students?</p>
-          <p>17. You are right. You aren't right. Are you right?</p>
-          <p>18. It's 6 o'clock. It isn't 6 o'clock. Is it 6 o'clock?</p>
-          <p>19. The table is blue. The table isn't blue. Is the table blue?</p>
-          <p>20. He is the new manager. He isn't the new manager. Is he the new manager?</p>
-          <p>21. They are sorry. They aren't sorry. Are they sorry?</p>
-          <p>22. We are in Spain. We're in Spain.</p>
-          <p>23. You are not my friend. You aren't my friend.</p>
-          <p>24. Sheila is from Brighton. Sheila's from Brighton.</p>
-          <p>25. The chairs are not expensive. The chairs aren't expensive.</p>
-          <p>26. I am not British. I'm not British.</p>
-          <p>27. Clara is a good student. Clara's a good student.</p>
-          <p>28. You are great. You're great.</p>
-          <p>29. They are my friends. They're my friends.</p>
-          <p>30. He is not angry. He isn't angry.</p>
+          <p>1. <mark>Are</mark> you a teacher? Yes, I <mark>am</mark>.</p>
+          <p>2. <mark>Is</mark> your name Marcus? Yes, it <mark>is</mark>.</p>
+          <p>3. <mark>Are</mark> your children here? No, they <mark>aren't</mark>.</p>
+          <p>4. <mark>Is</mark> this your suitcase? No, it <mark>isn't</mark>.</p>
+          <p>5. Where <mark>are</mark> we? I think this <mark>is</mark> Oxford Street.</p>
+          <p>6. <mark>Is</mark> it Saturday today? No, <mark>it's</mark> Sunday.</p>
+          <p>7. <mark>Are</mark> your friends from the UK? No, they <mark>are</mark> from the US.</p>
+          <p>8. Hello, Maria. How <mark>are</mark> you? <mark>I'm</mark> fine, thanks.</p>
+          <p>9. How old <mark>is</mark> Peter? I think he <mark>is</mark> 30 years old.</p>
+          <p>10. <mark>Are</mark> David and Molly here? Yes, <mark>they're</mark> next to the door.</p>
+          <p>11. She <mark>is</mark> fantastic. <mark>She's</mark> fantastic.</p>
+          <p>12. She <mark>is</mark> a teacher. She <mark>isn't</mark> a teacher. <mark>Is</mark> she a teacher?</p>
+          <p>13. <mark>They're</mark> in Berlin. They <mark>aren't</mark> in Berlin. <mark>Are</mark> they in Berlin?</p>
+          <p>14. <mark>It's</mark> a nice day. It <mark>isn't</mark> a nice day. <mark>Is</mark> it a nice day?</p>
+          <p>15. I <mark>am</mark> very excited. <mark>I'm</mark> not very excited. <mark>Am</mark> I very excited?</p>
+          <p>16. We <mark>are</mark> students. We <mark>aren't</mark> students. <mark>Are</mark> we students?</p>
+          <p>17. You <mark>are</mark> right. You <mark>aren't</mark> right. <mark>Are</mark> you right?</p>
+          <p>18. <mark>It's</mark> 6 o'clock. It <mark>isn't</mark> 6 o'clock. <mark>Is</mark> it 6 o'clock?</p>
+          <p>19. The table <mark>is</mark> blue. The table <mark>isn't</mark> blue. <mark>Is</mark> the table blue?</p>
+          <p>20. He <mark>is</mark> the new manager. He <mark>isn't</mark> the new manager. <mark>Is</mark> he the new manager?</p>
+          <p>21. They <mark>are</mark> sorry. They <mark>aren't</mark> sorry. <mark>Are</mark> they sorry?</p>
+          <p>22. We <mark>are</mark> in Spain. <mark>We're</mark> in Spain.</p>
+          <p>23. You <mark>are</mark> not my friend. You <mark>aren't</mark> my friend.</p>
+          <p>24. Sheila <mark>is</mark> from Brighton. <mark>Sheila's</mark> from Brighton.</p>
+          <p>25. The chairs <mark>are</mark> not expensive. The chairs <mark>aren't</mark> expensive.</p>
+          <p>26. I <mark>am</mark> not British. <mark>I'm</mark> not British.</p>
+          <p>27. Clara <mark>is</mark> a good student. <mark>Clara's</mark> a good student.</p>
+          <p>28. You <mark>are</mark> great. <mark>You're</mark> great.</p>
+          <p>29. They <mark>are</mark> my friends. <mark>They're</mark> my friends.</p>
+          <p>30. He <mark>is</mark> not angry. He <mark>isn't</mark> angry.</p>
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- rename examples tab label to `Exemples`
- highlight verb *to be* forms in the examples section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854594794708323a8a0ca1c36ebaabf