### PR TITLE
Add audio playback buttons for 'to be' examples

### DIFF
--- a/grammar/a1-elementary/to-be.html
+++ b/grammar/a1-elementary/to-be.html
@@ -431,6 +431,21 @@
           document.getElementById(btn.dataset.tab).classList.add('active');
         });
       });
+
+      // Adiciona botões de áudio para cada exemplo
+      document.querySelectorAll('#exercises .example-container p').forEach(p => {
+        const btn = document.createElement('button');
+        btn.textContent = '🔊';
+        btn.className = 'tts-btn';
+        btn.type = 'button';
+        btn.addEventListener('click', () => {
+          const utter = new SpeechSynthesisUtterance(p.textContent);
+          const voice = speechSynthesis.getVoices().find(v => v.name === 'Google US English');
+          if (voice) utter.voice = voice;
+          speechSynthesis.speak(utter);
+        });
+        p.appendChild(btn);
+      });
     });
   </script>
 </body>

--- a/style.css
+++ b/style.css
@@ -365,3 +365,13 @@ footer {
   font-weight: 700;
   font-size: 1rem;
 }
+
+/* Botão de reprodução de áudio nos exemplos */
+.tts-btn {
+  margin-left: 8px;
+  background: none;
+  border: none;
+  color: #00bcd4;
+  cursor: pointer;
+  font-size: 1rem;
+}


### PR DESCRIPTION
## Summary
- add playback buttons to each example on the 'to be' page
- style the new audio buttons

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68545f3101b48323b196d90634bcef79