### PR TITLE
Center page with grid layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ O **BR-English** oferece:
 - **Dropdown de níveis** em “Grammar”, “Vocabulary”, “Listening” e “Reading”: A1, A2, B1, B1+ e B2, cada um com ícone circular colorido.
 - **Responsividade**: menu “hamburger” para dispositivos móveis.  
 - **Acessibilidade**: botão flutuante de alto contraste.  
-- **Seção hero centralizada** com título e subtítulo posicionados verticalmente no centro da viewport.
+- **Seção hero centralizada** em uma coluna central, com título e subtítulo alinhados no centro da viewport.
 
 ## Tecnologias Utilizadas
 

--- a/grammar/a1-elementary/demonstratives.html
+++ b/grammar/a1-elementary/demonstratives.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="../../style.css" />
 </head>
 <body>
+  <div class="page">
   <header>
     <nav class="navbar">
       <a href="../../index.html" class="logo">
@@ -174,6 +175,7 @@
   <footer>
     © 2025 BR-English. Todos os direitos reservados.
   </footer>
+  </div>
 
   <script src="../../script.js"></script>
   <script>

--- a/grammar/a1-elementary/index.html
+++ b/grammar/a1-elementary/index.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="../../style.css" />
 </head>
 <body>
+  <div class="page">
   <header>
     <nav class="navbar">
       <a href="../../index.html" class="logo">
@@ -170,6 +171,7 @@
   <footer>
     © 2025 BR-English. Todos os direitos reservados.
   </footer>
+  </div>
 
   <script src="../../script.js"></script>
 </body>

--- a/grammar/a1-elementary/possessives-and-pronouns.html
+++ b/grammar/a1-elementary/possessives-and-pronouns.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="../../style.css" />
 </head>
 <body>
+  <div class="page">
   <header>
     <nav class="navbar">
       <a href="../../index.html" class="logo">
@@ -174,6 +175,7 @@
   <footer>
     © 2025 BR-English. Todos os direitos reservados.
   </footer>
+  </div>
 
   <script src="../../script.js"></script>
   <script>

--- a/grammar/a1-elementary/to-be.html
+++ b/grammar/a1-elementary/to-be.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="../../style.css" />
 </head>
 <body>
+  <div class="page">
   <header>
     <nav class="navbar">
       <a href="../../index.html" class="logo">
@@ -417,6 +418,7 @@
   <footer>
     © 2025 BR-English. Todos os direitos reservados.
   </footer>
+  </div>
 
   <script src="../../script.js"></script>
   <script>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+  <div class="page">
   <header>
     <nav class="navbar">
       <a href="index.html" class="logo">
@@ -168,6 +169,7 @@
   <footer>
     © 2025 BR-English. Todos os direitos reservados.
   </footer>
+  </div>
 
   <script src="script.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -11,6 +11,15 @@ body {
   line-height: 1.5;
 }
 
+.page {
+  display: grid;
+  grid-template-columns: 1fr minmax(auto, 800px) 1fr;
+}
+.page > * {
+  grid-column: 2;
+}
+
+
 /* ==== NAVBAR ==== */
 .navbar {
   display: flex;
@@ -268,6 +277,7 @@ footer {
 
 /* ==== RESPONSIVO ==== */
 @media (max-width: 768px) {
+  .page { grid-template-columns: 1fr; }
   .menu { display: none; }
   .hamburger { display: flex; }
   .menu.open {


### PR DESCRIPTION
## Summary
- wrap body content with `.page` container
- style `.page` as a three-column grid and collapse to one column on mobile
- update hero section description in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68559741d1548323bee001186a0f4a09