### PR TITLE
Fix hero and lesson title fonts

### DIFF
--- a/style.css
+++ b/style.css
@@ -155,7 +155,8 @@ body {
   padding: 20px;
 }
 .hero h1 {
-  font-size: clamp(2rem, 5vw, 3rem);
+  font-size: 11px;
+  /* Fixed size to ensure consistent display */
   font-weight: 700;
 }
 .hero p {
@@ -308,7 +309,7 @@ footer {
 }
 
 @media (max-width: 480px) {
-  .hero h1 { font-size: 2rem; }
+  .hero h1 { font-size: 11px; }
   .hero p { font-size: 1rem; }
 }
 /* ==== CUSTOM DARK MODE ELEMENTS ==== */
@@ -388,7 +389,7 @@ footer {
 
 /* ==== LESSON TITLE ==== */
 .lesson-title {
-  font-size: 1rem; /* Same as the logo text */
+  font-size: 11px; /* Same as the logo text */
   font-weight: 700;
   text-align: center;
 }


### PR DESCRIPTION
## Summary
- set `.hero h1` font to a fixed 11px size
- keep 11px size for `.hero h1` on mobile
- match `.lesson-title` size to 11px

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68559d0f08cc83238ebc1a4a7aa30324