### PR TITLE
Add A1 grammar placeholders and links

### DIFF
--- a/grammar/a1-elementary/adverbs-of-frequency.html
+++ b/grammar/a1-elementary/adverbs-of-frequency.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="BR-English is a responsive site with grammar, vocabulary, listening and reading resources from levels A1 to B2." />
-  <title>A1 Grammar Lessons and Exercises</title>
+  <title>Advérbios de frequência (always, often, never…) e posição na frase</title>
   <link rel="stylesheet" href="../../style.css" />
 </head>
 <body>
@@ -158,30 +158,17 @@
 
   <main class="hero">
     <div class="content">
-      <h1>A1 Grammar Lessons and Exercises</h1>
-      <p>Blocos gramaticais essenciais do nível A1</p>
-      <ul class="lesson-links">
-        <li><a href="to-be.html">Verbo “to be” – formas e contrações (am / is / are)</a></li>
-        <li><a href="possessives-and-pronouns.html">Pronomes pessoais do sujeito e adjetivos possessivos (I / my, you / your…)</a></li>
-        <li><a href="demonstratives.html">Demonstrativos (this, that, these, those)</a></li>
-        <li><a href="articles.html">Artigos indefinidos, definidos e ausência de artigo (a / an, the, Ø)</a></li>
-        <li><a href="plurals.html">Formação do plural – regulares e irregulares</a></li>
-        <li><a href="basic-word-order.html">Ordem básica da frase afirmativa (Sujeito + Verbo + Objeto)</a></li>
-        <li><a href="present-simple.html">Presente simples – forma afirmativa, negativa e interrogativa (do / does)</a></li>
-        <li><a href="adverbs-of-frequency.html">Advérbios de frequência (always, often, never…) e posição na frase</a></li>
-        <li><a href="object-vs-subject-pronouns.html">Pronomes objeto vs. pronomes sujeito (me / I, her / she…)</a></li>
-        <li><a href="wh-questions.html">Wh-questions – palavras interrogativas e ordem das palavras</a></li>
-        <li><a href="prepositions-place-time.html">Preposições de lugar (in, on, under…) e de tempo (at, on, in)</a></li>
-        <li><a href="imperative.html">Imperativo – ordens afirmativas e negativas</a></li>
-        <li><a href="can-cant.html">Can / can’t para habilidade, possibilidade e permissão</a></li>
-        <li><a href="present-continuous-vs-simple.html">Presente contínuo (am / is / are + -ing) vs. presente simples</a></li>
-        <li><a href="there-is-there-are.html">There is / There are + substantivos contáveis e incontáveis</a></li>
-        <li><a href="some-any.html">Some / any com substantivos contáveis e incontáveis</a></li>
-        <li><a href="past-be-and-past-simple.html">Passado do to be (was / were) e passado simples básico (verbos regulares e irregulares)</a></li>
-        <li><a href="be-going-to.html">Be going to para planos e previsões (ponte do fim do A1 para o A2)</a></li>
-        <li><a href="comparatives-and-superlatives.html">Comparativos e superlativos (older, the oldest)</a></li>
-        <li><a href="basic-conjunctions.html">Conjunções básicas (and, but, or, so, because)</a></li>
-      </ul>
+      <h1>Advérbios de frequência (always, often, never…) e posição na frase</h1>
+      <div class="tabs">
+      <button class="tab-button active" data-tab="explanation">Explanation</button>
+      <button class="tab-button" data-tab="exercises">Exercises</button>
+    </div>
+    <section id="explanation" class="tab-content active">
+      <p>Conteúdo em breve.
+    </section>
+      <section id="exercises" class="tab-content">
+        <p>Exercícios em breve.</p>
+      </section>
     </div>
   </main>
 
@@ -191,5 +178,19 @@
   </div>
 
   <script src="../../script.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const buttons = document.querySelectorAll('.tab-button');
+      const contents = document.querySelectorAll('.tab-content');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          buttons.forEach(b => b.classList.remove('active'));
+          contents.forEach(c => c.classList.remove('active'));
+          btn.classList.add('active');
+          document.getElementById(btn.dataset.tab).classList.add('active');
+        });
+      });
+    });
+  </script>
 </body>
 </html>

--- a/grammar/a1-elementary/articles.html
+++ b/grammar/a1-elementary/articles.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="BR-English is a responsive site with grammar, vocabulary, listening and reading resources from levels A1 to B2." />
-  <title>A1 Grammar Lessons and Exercises</title>
+  <title>Artigos indefinidos, definidos e ausência de artigo (a / an, the, Ø)</title>
   <link rel="stylesheet" href="../../style.css" />
 </head>
 <body>
@@ -158,30 +158,17 @@
 
   <main class="hero">
     <div class="content">
-      <h1>A1 Grammar Lessons and Exercises</h1>
-      <p>Blocos gramaticais essenciais do nível A1</p>
-      <ul class="lesson-links">
-        <li><a href="to-be.html">Verbo “to be” – formas e contrações (am / is / are)</a></li>
-        <li><a href="possessives-and-pronouns.html">Pronomes pessoais do sujeito e adjetivos possessivos (I / my, you / your…)</a></li>
-        <li><a href="demonstratives.html">Demonstrativos (this, that, these, those)</a></li>
-        <li><a href="articles.html">Artigos indefinidos, definidos e ausência de artigo (a / an, the, Ø)</a></li>
-        <li><a href="plurals.html">Formação do plural – regulares e irregulares</a></li>
-        <li><a href="basic-word-order.html">Ordem básica da frase afirmativa (Sujeito + Verbo + Objeto)</a></li>
-        <li><a href="present-simple.html">Presente simples – forma afirmativa, negativa e interrogativa (do / does)</a></li>
-        <li><a href="adverbs-of-frequency.html">Advérbios de frequência (always, often, never…) e posição na frase</a></li>
-        <li><a href="object-vs-subject-pronouns.html">Pronomes objeto vs. pronomes sujeito (me / I, her / she…)</a></li>
-        <li><a href="wh-questions.html">Wh-questions – palavras interrogativas e ordem das palavras</a></li>
-        <li><a href="prepositions-place-time.html">Preposições de lugar (in, on, under…) e de tempo (at, on, in)</a></li>
-        <li><a href="imperative.html">Imperativo – ordens afirmativas e negativas</a></li>
-        <li><a href="can-cant.html">Can / can’t para habilidade, possibilidade e permissão</a></li>
-        <li><a href="present-continuous-vs-simple.html">Presente contínuo (am / is / are + -ing) vs. presente simples</a></li>
-        <li><a href="there-is-there-are.html">There is / There are + substantivos contáveis e incontáveis</a></li>
-        <li><a href="some-any.html">Some / any com substantivos contáveis e incontáveis</a></li>
-        <li><a href="past-be-and-past-simple.html">Passado do to be (was / were) e passado simples básico (verbos regulares e irregulares)</a></li>
-        <li><a href="be-going-to.html">Be going to para planos e previsões (ponte do fim do A1 para o A2)</a></li>
-        <li><a href="comparatives-and-superlatives.html">Comparativos e superlativos (older, the oldest)</a></li>
-        <li><a href="basic-conjunctions.html">Conjunções básicas (and, but, or, so, because)</a></li>
-      </ul>
+      <h1>Artigos indefinidos, definidos e ausência de artigo (a / an, the, Ø)</h1>
+      <div class="tabs">
+      <button class="tab-button active" data-tab="explanation">Explanation</button>
+      <button class="tab-button" data-tab="exercises">Exercises</button>
+    </div>
+    <section id="explanation" class="tab-content active">
+      <p>Conteúdo em breve.
+    </section>
+      <section id="exercises" class="tab-content">
+        <p>Exercícios em breve.</p>
+      </section>
     </div>
   </main>
 
@@ -191,5 +178,19 @@
   </div>
 
   <script src="../../script.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const buttons = document.querySelectorAll('.tab-button');
+      const contents = document.querySelectorAll('.tab-content');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          buttons.forEach(b => b.classList.remove('active'));
+          contents.forEach(c => c.classList.remove('active'));
+          btn.classList.add('active');
+          document.getElementById(btn.dataset.tab).classList.add('active');
+        });
+      });
+    });
+  </script>
 </body>
 </html>

--- a/grammar/a1-elementary/basic-conjunctions.html
+++ b/grammar/a1-elementary/basic-conjunctions.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="BR-English is a responsive site with grammar, vocabulary, listening and reading resources from levels A1 to B2." />
-  <title>A1 Grammar Lessons and Exercises</title>
+  <title>Conjunções básicas (and, but, or, so, because)</title>
   <link rel="stylesheet" href="../../style.css" />
 </head>
 <body>
@@ -158,30 +158,17 @@
 
   <main class="hero">
     <div class="content">
-      <h1>A1 Grammar Lessons and Exercises</h1>
-      <p>Blocos gramaticais essenciais do nível A1</p>
-      <ul class="lesson-links">
-        <li><a href="to-be.html">Verbo “to be” – formas e contrações (am / is / are)</a></li>
-        <li><a href="possessives-and-pronouns.html">Pronomes pessoais do sujeito e adjetivos possessivos (I / my, you / your…)</a></li>
-        <li><a href="demonstratives.html">Demonstrativos (this, that, these, those)</a></li>
-        <li><a href="articles.html">Artigos indefinidos, definidos e ausência de artigo (a / an, the, Ø)</a></li>
-        <li><a href="plurals.html">Formação do plural – regulares e irregulares</a></li>
-        <li><a href="basic-word-order.html">Ordem básica da frase afirmativa (Sujeito + Verbo + Objeto)</a></li>
-        <li><a href="present-simple.html">Presente simples – forma afirmativa, negativa e interrogativa (do / does)</a></li>
-        <li><a href="adverbs-of-frequency.html">Advérbios de frequência (always, often, never…) e posição na frase</a></li>
-        <li><a href="object-vs-subject-pronouns.html">Pronomes objeto vs. pronomes sujeito (me / I, her / she…)</a></li>
-        <li><a href="wh-questions.html">Wh-questions – palavras interrogativas e ordem das palavras</a></li>
-        <li><a href="prepositions-place-time.html">Preposições de lugar (in, on, under…) e de tempo (at, on, in)</a></li>
-        <li><a href="imperative.html">Imperativo – ordens afirmativas e negativas</a></li>
-        <li><a href="can-cant.html">Can / can’t para habilidade, possibilidade e permissão</a></li>
-        <li><a href="present-continuous-vs-simple.html">Presente contínuo (am / is / are + -ing) vs. presente simples</a></li>
-        <li><a href="there-is-there-are.html">There is / There are + substantivos contáveis e incontáveis</a></li>
-        <li><a href="some-any.html">Some / any com substantivos contáveis e incontáveis</a></li>
-        <li><a href="past-be-and-past-simple.html">Passado do to be (was / were) e passado simples básico (verbos regulares e irregulares)</a></li>
-        <li><a href="be-going-to.html">Be going to para planos e previsões (ponte do fim do A1 para o A2)</a></li>
-        <li><a href="comparatives-and-superlatives.html">Comparativos e superlativos (older, the oldest)</a></li>
-        <li><a href="basic-conjunctions.html">Conjunções básicas (and, but, or, so, because)</a></li>
-      </ul>
+      <h1>Conjunções básicas (and, but, or, so, because)</h1>
+      <div class="tabs">
+      <button class="tab-button active" data-tab="explanation">Explanation</button>
+      <button class="tab-button" data-tab="exercises">Exercises</button>
+    </div>
+    <section id="explanation" class="tab-content active">
+      <p>Conteúdo em breve.
+    </section>
+      <section id="exercises" class="tab-content">
+        <p>Exercícios em breve.</p>
+      </section>
     </div>
   </main>
 
@@ -191,5 +178,19 @@
   </div>
 
   <script src="../../script.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const buttons = document.querySelectorAll('.tab-button');
+      const contents = document.querySelectorAll('.tab-content');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          buttons.forEach(b => b.classList.remove('active'));
+          contents.forEach(c => c.classList.remove('active'));
+          btn.classList.add('active');
+          document.getElementById(btn.dataset.tab).classList.add('active');
+        });
+      });
+    });
+  </script>
 </body>
 </html>

--- a/grammar/a1-elementary/basic-word-order.html
+++ b/grammar/a1-elementary/basic-word-order.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="BR-English is a responsive site with grammar, vocabulary, listening and reading resources from levels A1 to B2." />
-  <title>A1 Grammar Lessons and Exercises</title>
+  <title>Ordem básica da frase afirmativa (Sujeito + Verbo + Objeto)</title>
   <link rel="stylesheet" href="../../style.css" />
 </head>
 <body>
@@ -158,30 +158,17 @@
 
   <main class="hero">
     <div class="content">
-      <h1>A1 Grammar Lessons and Exercises</h1>
-      <p>Blocos gramaticais essenciais do nível A1</p>
-      <ul class="lesson-links">
-        <li><a href="to-be.html">Verbo “to be” – formas e contrações (am / is / are)</a></li>
-        <li><a href="possessives-and-pronouns.html">Pronomes pessoais do sujeito e adjetivos possessivos (I / my, you / your…)</a></li>
-        <li><a href="demonstratives.html">Demonstrativos (this, that, these, those)</a></li>
-        <li><a href="articles.html">Artigos indefinidos, definidos e ausência de artigo (a / an, the, Ø)</a></li>
-        <li><a href="plurals.html">Formação do plural – regulares e irregulares</a></li>
-        <li><a href="basic-word-order.html">Ordem básica da frase afirmativa (Sujeito + Verbo + Objeto)</a></li>
-        <li><a href="present-simple.html">Presente simples – forma afirmativa, negativa e interrogativa (do / does)</a></li>
-        <li><a href="adverbs-of-frequency.html">Advérbios de frequência (always, often, never…) e posição na frase</a></li>
-        <li><a href="object-vs-subject-pronouns.html">Pronomes objeto vs. pronomes sujeito (me / I, her / she…)</a></li>
-        <li><a href="wh-questions.html">Wh-questions – palavras interrogativas e ordem das palavras</a></li>
-        <li><a href="prepositions-place-time.html">Preposições de lugar (in, on, under…) e de tempo (at, on, in)</a></li>
-        <li><a href="imperative.html">Imperativo – ordens afirmativas e negativas</a></li>
-        <li><a href="can-cant.html">Can / can’t para habilidade, possibilidade e permissão</a></li>
-        <li><a href="present-continuous-vs-simple.html">Presente contínuo (am / is / are + -ing) vs. presente simples</a></li>
-        <li><a href="there-is-there-are.html">There is / There are + substantivos contáveis e incontáveis</a></li>
-        <li><a href="some-any.html">Some / any com substantivos contáveis e incontáveis</a></li>
-        <li><a href="past-be-and-past-simple.html">Passado do to be (was / were) e passado simples básico (verbos regulares e irregulares)</a></li>
-        <li><a href="be-going-to.html">Be going to para planos e previsões (ponte do fim do A1 para o A2)</a></li>
-        <li><a href="comparatives-and-superlatives.html">Comparativos e superlativos (older, the oldest)</a></li>
-        <li><a href="basic-conjunctions.html">Conjunções básicas (and, but, or, so, because)</a></li>
-      </ul>
+      <h1>Ordem básica da frase afirmativa (Sujeito + Verbo + Objeto)</h1>
+      <div class="tabs">
+      <button class="tab-button active" data-tab="explanation">Explanation</button>
+      <button class="tab-button" data-tab="exercises">Exercises</button>
+    </div>
+    <section id="explanation" class="tab-content active">
+      <p>Conteúdo em breve.
+    </section>
+      <section id="exercises" class="tab-content">
+        <p>Exercícios em breve.</p>
+      </section>
     </div>
   </main>
 
@@ -191,5 +178,19 @@
   </div>
 
   <script src="../../script.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const buttons = document.querySelectorAll('.tab-button');
+      const contents = document.querySelectorAll('.tab-content');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          buttons.forEach(b => b.classList.remove('active'));
+          contents.forEach(c => c.classList.remove('active'));
+          btn.classList.add('active');
+          document.getElementById(btn.dataset.tab).classList.add('active');
+        });
+      });
+    });
+  </script>
 </body>
 </html>

--- a/grammar/a1-elementary/be-going-to.html
+++ b/grammar/a1-elementary/be-going-to.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="BR-English is a responsive site with grammar, vocabulary, listening and reading resources from levels A1 to B2." />
-  <title>A1 Grammar Lessons and Exercises</title>
+  <title>Be going to para planos e previsões (ponte do fim do A1 para o A2)</title>
   <link rel="stylesheet" href="../../style.css" />
 </head>
 <body>
@@ -158,30 +158,17 @@
 
   <main class="hero">
     <div class="content">
-      <h1>A1 Grammar Lessons and Exercises</h1>
-      <p>Blocos gramaticais essenciais do nível A1</p>
-      <ul class="lesson-links">
-        <li><a href="to-be.html">Verbo “to be” – formas e contrações (am / is / are)</a></li>
-        <li><a href="possessives-and-pronouns.html">Pronomes pessoais do sujeito e adjetivos possessivos (I / my, you / your…)</a></li>
-        <li><a href="demonstratives.html">Demonstrativos (this, that, these, those)</a></li>
-        <li><a href="articles.html">Artigos indefinidos, definidos e ausência de artigo (a / an, the, Ø)</a></li>
-        <li><a href="plurals.html">Formação do plural – regulares e irregulares</a></li>
-        <li><a href="basic-word-order.html">Ordem básica da frase afirmativa (Sujeito + Verbo + Objeto)</a></li>
-        <li><a href="present-simple.html">Presente simples – forma afirmativa, negativa e interrogativa (do / does)</a></li>
-        <li><a href="adverbs-of-frequency.html">Advérbios de frequência (always, often, never…) e posição na frase</a></li>
-        <li><a href="object-vs-subject-pronouns.html">Pronomes objeto vs. pronomes sujeito (me / I, her / she…)</a></li>
-        <li><a href="wh-questions.html">Wh-questions – palavras interrogativas e ordem das palavras</a></li>
-        <li><a href="prepositions-place-time.html">Preposições de lugar (in, on, under…) e de tempo (at, on, in)</a></li>
-        <li><a href="imperative.html">Imperativo – ordens afirmativas e negativas</a></li>
-        <li><a href="can-cant.html">Can / can’t para habilidade, possibilidade e permissão</a></li>
-        <li><a href="present-continuous-vs-simple.html">Presente contínuo (am / is / are + -ing) vs. presente simples</a></li>
-        <li><a href="there-is-there-are.html">There is / There are + substantivos contáveis e incontáveis</a></li>
-        <li><a href="some-any.html">Some / any com substantivos contáveis e incontáveis</a></li>
-        <li><a href="past-be-and-past-simple.html">Passado do to be (was / were) e passado simples básico (verbos regulares e irregulares)</a></li>
-        <li><a href="be-going-to.html">Be going to para planos e previsões (ponte do fim do A1 para o A2)</a></li>
-        <li><a href="comparatives-and-superlatives.html">Comparativos e superlativos (older, the oldest)</a></li>
-        <li><a href="basic-conjunctions.html">Conjunções básicas (and, but, or, so, because)</a></li>
-      </ul>
+      <h1>Be going to para planos e previsões (ponte do fim do A1 para o A2)</h1>
+      <div class="tabs">
+      <button class="tab-button active" data-tab="explanation">Explanation</button>
+      <button class="tab-button" data-tab="exercises">Exercises</button>
+    </div>
+    <section id="explanation" class="tab-content active">
+      <p>Conteúdo em breve.
+    </section>
+      <section id="exercises" class="tab-content">
+        <p>Exercícios em breve.</p>
+      </section>
     </div>
   </main>
 
@@ -191,5 +178,19 @@
   </div>
 
   <script src="../../script.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const buttons = document.querySelectorAll('.tab-button');
+      const contents = document.querySelectorAll('.tab-content');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          buttons.forEach(b => b.classList.remove('active'));
+          contents.forEach(c => c.classList.remove('active'));
+          btn.classList.add('active');
+          document.getElementById(btn.dataset.tab).classList.add('active');
+        });
+      });
+    });
+  </script>
 </body>
 </html>

--- a/grammar/a1-elementary/can-cant.html
+++ b/grammar/a1-elementary/can-cant.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="BR-English is a responsive site with grammar, vocabulary, listening and reading resources from levels A1 to B2." />
-  <title>A1 Grammar Lessons and Exercises</title>
+  <title>Can / can’t para habilidade, possibilidade e permissão</title>
   <link rel="stylesheet" href="../../style.css" />
 </head>
 <body>
@@ -158,30 +158,17 @@
 
   <main class="hero">
     <div class="content">
-      <h1>A1 Grammar Lessons and Exercises</h1>
-      <p>Blocos gramaticais essenciais do nível A1</p>
-      <ul class="lesson-links">
-        <li><a href="to-be.html">Verbo “to be” – formas e contrações (am / is / are)</a></li>
-        <li><a href="possessives-and-pronouns.html">Pronomes pessoais do sujeito e adjetivos possessivos (I / my, you / your…)</a></li>
-        <li><a href="demonstratives.html">Demonstrativos (this, that, these, those)</a></li>
-        <li><a href="articles.html">Artigos indefinidos, definidos e ausência de artigo (a / an, the, Ø)</a></li>
-        <li><a href="plurals.html">Formação do plural – regulares e irregulares</a></li>
-        <li><a href="basic-word-order.html">Ordem básica da frase afirmativa (Sujeito + Verbo + Objeto)</a></li>
-        <li><a href="present-simple.html">Presente simples – forma afirmativa, negativa e interrogativa (do / does)</a></li>
-        <li><a href="adverbs-of-frequency.html">Advérbios de frequência (always, often, never…) e posição na frase</a></li>
-        <li><a href="object-vs-subject-pronouns.html">Pronomes objeto vs. pronomes sujeito (me / I, her / she…)</a></li>
-        <li><a href="wh-questions.html">Wh-questions – palavras interrogativas e ordem das palavras</a></li>
-        <li><a href="prepositions-place-time.html">Preposições de lugar (in, on, under…) e de tempo (at, on, in)</a></li>
-        <li><a href="imperative.html">Imperativo – ordens afirmativas e negativas</a></li>
-        <li><a href="can-cant.html">Can / can’t para habilidade, possibilidade e permissão</a></li>
-        <li><a href="present-continuous-vs-simple.html">Presente contínuo (am / is / are + -ing) vs. presente simples</a></li>
-        <li><a href="there-is-there-are.html">There is / There are + substantivos contáveis e incontáveis</a></li>
-        <li><a href="some-any.html">Some / any com substantivos contáveis e incontáveis</a></li>
-        <li><a href="past-be-and-past-simple.html">Passado do to be (was / were) e passado simples básico (verbos regulares e irregulares)</a></li>
-        <li><a href="be-going-to.html">Be going to para planos e previsões (ponte do fim do A1 para o A2)</a></li>
-        <li><a href="comparatives-and-superlatives.html">Comparativos e superlativos (older, the oldest)</a></li>
-        <li><a href="basic-conjunctions.html">Conjunções básicas (and, but, or, so, because)</a></li>
-      </ul>
+      <h1>Can / can’t para habilidade, possibilidade e permissão</h1>
+      <div class="tabs">
+      <button class="tab-button active" data-tab="explanation">Explanation</button>
+      <button class="tab-button" data-tab="exercises">Exercises</button>
+    </div>
+    <section id="explanation" class="tab-content active">
+      <p>Conteúdo em breve.
+    </section>
+      <section id="exercises" class="tab-content">
+        <p>Exercícios em breve.</p>
+      </section>
     </div>
   </main>
 
@@ -191,5 +178,19 @@
   </div>
 
   <script src="../../script.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const buttons = document.querySelectorAll('.tab-button');
+      const contents = document.querySelectorAll('.tab-content');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          buttons.forEach(b => b.classList.remove('active'));
+          contents.forEach(c => c.classList.remove('active'));
+          btn.classList.add('active');
+          document.getElementById(btn.dataset.tab).classList.add('active');
+        });
+      });
+    });
+  </script>
 </body>
 </html>

--- a/grammar/a1-elementary/comparatives-and-superlatives.html
+++ b/grammar/a1-elementary/comparatives-and-superlatives.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="BR-English is a responsive site with grammar, vocabulary, listening and reading resources from levels A1 to B2." />
-  <title>A1 Grammar Lessons and Exercises</title>
+  <title>Comparativos e superlativos (older, the oldest)</title>
   <link rel="stylesheet" href="../../style.css" />
 </head>
 <body>
@@ -158,30 +158,17 @@
 
   <main class="hero">
     <div class="content">
-      <h1>A1 Grammar Lessons and Exercises</h1>
-      <p>Blocos gramaticais essenciais do nível A1</p>
-      <ul class="lesson-links">
-        <li><a href="to-be.html">Verbo “to be” – formas e contrações (am / is / are)</a></li>
-        <li><a href="possessives-and-pronouns.html">Pronomes pessoais do sujeito e adjetivos possessivos (I / my, you / your…)</a></li>
-        <li><a href="demonstratives.html">Demonstrativos (this, that, these, those)</a></li>
-        <li><a href="articles.html">Artigos indefinidos, definidos e ausência de artigo (a / an, the, Ø)</a></li>
-        <li><a href="plurals.html">Formação do plural – regulares e irregulares</a></li>
-        <li><a href="basic-word-order.html">Ordem básica da frase afirmativa (Sujeito + Verbo + Objeto)</a></li>
-        <li><a href="present-simple.html">Presente simples – forma afirmativa, negativa e interrogativa (do / does)</a></li>
-        <li><a href="adverbs-of-frequency.html">Advérbios de frequência (always, often, never…) e posição na frase</a></li>
-        <li><a href="object-vs-subject-pronouns.html">Pronomes objeto vs. pronomes sujeito (me / I, her / she…)</a></li>
-        <li><a href="wh-questions.html">Wh-questions – palavras interrogativas e ordem das palavras</a></li>
-        <li><a href="prepositions-place-time.html">Preposições de lugar (in, on, under…) e de tempo (at, on, in)</a></li>
-        <li><a href="imperative.html">Imperativo – ordens afirmativas e negativas</a></li>
-        <li><a href="can-cant.html">Can / can’t para habilidade, possibilidade e permissão</a></li>
-        <li><a href="present-continuous-vs-simple.html">Presente contínuo (am / is / are + -ing) vs. presente simples</a></li>
-        <li><a href="there-is-there-are.html">There is / There are + substantivos contáveis e incontáveis</a></li>
-        <li><a href="some-any.html">Some / any com substantivos contáveis e incontáveis</a></li>
-        <li><a href="past-be-and-past-simple.html">Passado do to be (was / were) e passado simples básico (verbos regulares e irregulares)</a></li>
-        <li><a href="be-going-to.html">Be going to para planos e previsões (ponte do fim do A1 para o A2)</a></li>
-        <li><a href="comparatives-and-superlatives.html">Comparativos e superlativos (older, the oldest)</a></li>
-        <li><a href="basic-conjunctions.html">Conjunções básicas (and, but, or, so, because)</a></li>
-      </ul>
+      <h1>Comparativos e superlativos (older, the oldest)</h1>
+      <div class="tabs">
+      <button class="tab-button active" data-tab="explanation">Explanation</button>
+      <button class="tab-button" data-tab="exercises">Exercises</button>
+    </div>
+    <section id="explanation" class="tab-content active">
+      <p>Conteúdo em breve.
+    </section>
+      <section id="exercises" class="tab-content">
+        <p>Exercícios em breve.</p>
+      </section>
     </div>
   </main>
 
@@ -191,5 +178,19 @@
   </div>
 
   <script src="../../script.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const buttons = document.querySelectorAll('.tab-button');
+      const contents = document.querySelectorAll('.tab-content');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          buttons.forEach(b => b.classList.remove('active'));
+          contents.forEach(c => c.classList.remove('active'));
+          btn.classList.add('active');
+          document.getElementById(btn.dataset.tab).classList.add('active');
+        });
+      });
+    });
+  </script>
 </body>
 </html>

--- a/grammar/a1-elementary/imperative.html
+++ b/grammar/a1-elementary/imperative.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="BR-English is a responsive site with grammar, vocabulary, listening and reading resources from levels A1 to B2." />
-  <title>A1 Grammar Lessons and Exercises</title>
+  <title>Imperativo – ordens afirmativas e negativas</title>
   <link rel="stylesheet" href="../../style.css" />
 </head>
 <body>
@@ -158,30 +158,17 @@
 
   <main class="hero">
     <div class="content">
-      <h1>A1 Grammar Lessons and Exercises</h1>
-      <p>Blocos gramaticais essenciais do nível A1</p>
-      <ul class="lesson-links">
-        <li><a href="to-be.html">Verbo “to be” – formas e contrações (am / is / are)</a></li>
-        <li><a href="possessives-and-pronouns.html">Pronomes pessoais do sujeito e adjetivos possessivos (I / my, you / your…)</a></li>
-        <li><a href="demonstratives.html">Demonstrativos (this, that, these, those)</a></li>
-        <li><a href="articles.html">Artigos indefinidos, definidos e ausência de artigo (a / an, the, Ø)</a></li>
-        <li><a href="plurals.html">Formação do plural – regulares e irregulares</a></li>
-        <li><a href="basic-word-order.html">Ordem básica da frase afirmativa (Sujeito + Verbo + Objeto)</a></li>
-        <li><a href="present-simple.html">Presente simples – forma afirmativa, negativa e interrogativa (do / does)</a></li>
-        <li><a href="adverbs-of-frequency.html">Advérbios de frequência (always, often, never…) e posição na frase</a></li>
-        <li><a href="object-vs-subject-pronouns.html">Pronomes objeto vs. pronomes sujeito (me / I, her / she…)</a></li>
-        <li><a href="wh-questions.html">Wh-questions – palavras interrogativas e ordem das palavras</a></li>
-        <li><a href="prepositions-place-time.html">Preposições de lugar (in, on, under…) e de tempo (at, on, in)</a></li>
-        <li><a href="imperative.html">Imperativo – ordens afirmativas e negativas</a></li>
-        <li><a href="can-cant.html">Can / can’t para habilidade, possibilidade e permissão</a></li>
-        <li><a href="present-continuous-vs-simple.html">Presente contínuo (am / is / are + -ing) vs. presente simples</a></li>
-        <li><a href="there-is-there-are.html">There is / There are + substantivos contáveis e incontáveis</a></li>
-        <li><a href="some-any.html">Some / any com substantivos contáveis e incontáveis</a></li>
-        <li><a href="past-be-and-past-simple.html">Passado do to be (was / were) e passado simples básico (verbos regulares e irregulares)</a></li>
-        <li><a href="be-going-to.html">Be going to para planos e previsões (ponte do fim do A1 para o A2)</a></li>
-        <li><a href="comparatives-and-superlatives.html">Comparativos e superlativos (older, the oldest)</a></li>
-        <li><a href="basic-conjunctions.html">Conjunções básicas (and, but, or, so, because)</a></li>
-      </ul>
+      <h1>Imperativo – ordens afirmativas e negativas</h1>
+      <div class="tabs">
+      <button class="tab-button active" data-tab="explanation">Explanation</button>
+      <button class="tab-button" data-tab="exercises">Exercises</button>
+    </div>
+    <section id="explanation" class="tab-content active">
+      <p>Conteúdo em breve.
+    </section>
+      <section id="exercises" class="tab-content">
+        <p>Exercícios em breve.</p>
+      </section>
     </div>
   </main>
 
@@ -191,5 +178,19 @@
   </div>
 
   <script src="../../script.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const buttons = document.querySelectorAll('.tab-button');
+      const contents = document.querySelectorAll('.tab-content');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          buttons.forEach(b => b.classList.remove('active'));
+          contents.forEach(c => c.classList.remove('active'));
+          btn.classList.add('active');
+          document.getElementById(btn.dataset.tab).classList.add('active');
+        });
+      });
+    });
+  </script>
 </body>
 </html>

--- a/grammar/a1-elementary/object-vs-subject-pronouns.html
+++ b/grammar/a1-elementary/object-vs-subject-pronouns.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="BR-English is a responsive site with grammar, vocabulary, listening and reading resources from levels A1 to B2." />
-  <title>A1 Grammar Lessons and Exercises</title>
+  <title>Pronomes objeto vs. pronomes sujeito (me / I, her / she…)</title>
   <link rel="stylesheet" href="../../style.css" />
 </head>
 <body>
@@ -158,30 +158,17 @@
 
   <main class="hero">
     <div class="content">
-      <h1>A1 Grammar Lessons and Exercises</h1>
-      <p>Blocos gramaticais essenciais do nível A1</p>
-      <ul class="lesson-links">
-        <li><a href="to-be.html">Verbo “to be” – formas e contrações (am / is / are)</a></li>
-        <li><a href="possessives-and-pronouns.html">Pronomes pessoais do sujeito e adjetivos possessivos (I / my, you / your…)</a></li>
-        <li><a href="demonstratives.html">Demonstrativos (this, that, these, those)</a></li>
-        <li><a href="articles.html">Artigos indefinidos, definidos e ausência de artigo (a / an, the, Ø)</a></li>
-        <li><a href="plurals.html">Formação do plural – regulares e irregulares</a></li>
-        <li><a href="basic-word-order.html">Ordem básica da frase afirmativa (Sujeito + Verbo + Objeto)</a></li>
-        <li><a href="present-simple.html">Presente simples – forma afirmativa, negativa e interrogativa (do / does)</a></li>
-        <li><a href="adverbs-of-frequency.html">Advérbios de frequência (always, often, never…) e posição na frase</a></li>
-        <li><a href="object-vs-subject-pronouns.html">Pronomes objeto vs. pronomes sujeito (me / I, her / she…)</a></li>
-        <li><a href="wh-questions.html">Wh-questions – palavras interrogativas e ordem das palavras</a></li>
-        <li><a href="prepositions-place-time.html">Preposições de lugar (in, on, under…) e de tempo (at, on, in)</a></li>
-        <li><a href="imperative.html">Imperativo – ordens afirmativas e negativas</a></li>
-        <li><a href="can-cant.html">Can / can’t para habilidade, possibilidade e permissão</a></li>
-        <li><a href="present-continuous-vs-simple.html">Presente contínuo (am / is / are + -ing) vs. presente simples</a></li>
-        <li><a href="there-is-there-are.html">There is / There are + substantivos contáveis e incontáveis</a></li>
-        <li><a href="some-any.html">Some / any com substantivos contáveis e incontáveis</a></li>
-        <li><a href="past-be-and-past-simple.html">Passado do to be (was / were) e passado simples básico (verbos regulares e irregulares)</a></li>
-        <li><a href="be-going-to.html">Be going to para planos e previsões (ponte do fim do A1 para o A2)</a></li>
-        <li><a href="comparatives-and-superlatives.html">Comparativos e superlativos (older, the oldest)</a></li>
-        <li><a href="basic-conjunctions.html">Conjunções básicas (and, but, or, so, because)</a></li>
-      </ul>
+      <h1>Pronomes objeto vs. pronomes sujeito (me / I, her / she…)</h1>
+      <div class="tabs">
+      <button class="tab-button active" data-tab="explanation">Explanation</button>
+      <button class="tab-button" data-tab="exercises">Exercises</button>
+    </div>
+    <section id="explanation" class="tab-content active">
+      <p>Conteúdo em breve.
+    </section>
+      <section id="exercises" class="tab-content">
+        <p>Exercícios em breve.</p>
+      </section>
     </div>
   </main>
 
@@ -191,5 +178,19 @@
   </div>
 
   <script src="../../script.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const buttons = document.querySelectorAll('.tab-button');
+      const contents = document.querySelectorAll('.tab-content');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          buttons.forEach(b => b.classList.remove('active'));
+          contents.forEach(c => c.classList.remove('active'));
+          btn.classList.add('active');
+          document.getElementById(btn.dataset.tab).classList.add('active');
+        });
+      });
+    });
+  </script>
 </body>
 </html>

--- a/grammar/a1-elementary/past-be-and-past-simple.html
+++ b/grammar/a1-elementary/past-be-and-past-simple.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="BR-English is a responsive site with grammar, vocabulary, listening and reading resources from levels A1 to B2." />
-  <title>A1 Grammar Lessons and Exercises</title>
+  <title>Passado do to be (was / were) e passado simples básico (verbos regulares e irregulares)</title>
   <link rel="stylesheet" href="../../style.css" />
 </head>
 <body>
@@ -158,30 +158,17 @@
 
   <main class="hero">
     <div class="content">
-      <h1>A1 Grammar Lessons and Exercises</h1>
-      <p>Blocos gramaticais essenciais do nível A1</p>
-      <ul class="lesson-links">
-        <li><a href="to-be.html">Verbo “to be” – formas e contrações (am / is / are)</a></li>
-        <li><a href="possessives-and-pronouns.html">Pronomes pessoais do sujeito e adjetivos possessivos (I / my, you / your…)</a></li>
-        <li><a href="demonstratives.html">Demonstrativos (this, that, these, those)</a></li>
-        <li><a href="articles.html">Artigos indefinidos, definidos e ausência de artigo (a / an, the, Ø)</a></li>
-        <li><a href="plurals.html">Formação do plural – regulares e irregulares</a></li>
-        <li><a href="basic-word-order.html">Ordem básica da frase afirmativa (Sujeito + Verbo + Objeto)</a></li>
-        <li><a href="present-simple.html">Presente simples – forma afirmativa, negativa e interrogativa (do / does)</a></li>
-        <li><a href="adverbs-of-frequency.html">Advérbios de frequência (always, often, never…) e posição na frase</a></li>
-        <li><a href="object-vs-subject-pronouns.html">Pronomes objeto vs. pronomes sujeito (me / I, her / she…)</a></li>
-        <li><a href="wh-questions.html">Wh-questions – palavras interrogativas e ordem das palavras</a></li>
-        <li><a href="prepositions-place-time.html">Preposições de lugar (in, on, under…) e de tempo (at, on, in)</a></li>
-        <li><a href="imperative.html">Imperativo – ordens afirmativas e negativas</a></li>
-        <li><a href="can-cant.html">Can / can’t para habilidade, possibilidade e permissão</a></li>
-        <li><a href="present-continuous-vs-simple.html">Presente contínuo (am / is / are + -ing) vs. presente simples</a></li>
-        <li><a href="there-is-there-are.html">There is / There are + substantivos contáveis e incontáveis</a></li>
-        <li><a href="some-any.html">Some / any com substantivos contáveis e incontáveis</a></li>
-        <li><a href="past-be-and-past-simple.html">Passado do to be (was / were) e passado simples básico (verbos regulares e irregulares)</a></li>
-        <li><a href="be-going-to.html">Be going to para planos e previsões (ponte do fim do A1 para o A2)</a></li>
-        <li><a href="comparatives-and-superlatives.html">Comparativos e superlativos (older, the oldest)</a></li>
-        <li><a href="basic-conjunctions.html">Conjunções básicas (and, but, or, so, because)</a></li>
-      </ul>
+      <h1>Passado do to be (was / were) e passado simples básico (verbos regulares e irregulares)</h1>
+      <div class="tabs">
+      <button class="tab-button active" data-tab="explanation">Explanation</button>
+      <button class="tab-button" data-tab="exercises">Exercises</button>
+    </div>
+    <section id="explanation" class="tab-content active">
+      <p>Conteúdo em breve.
+    </section>
+      <section id="exercises" class="tab-content">
+        <p>Exercícios em breve.</p>
+      </section>
     </div>
   </main>
 
@@ -191,5 +178,19 @@
   </div>
 
   <script src="../../script.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const buttons = document.querySelectorAll('.tab-button');
+      const contents = document.querySelectorAll('.tab-content');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          buttons.forEach(b => b.classList.remove('active'));
+          contents.forEach(c => c.classList.remove('active'));
+          btn.classList.add('active');
+          document.getElementById(btn.dataset.tab).classList.add('active');
+        });
+      });
+    });
+  </script>
 </body>
 </html>

--- a/grammar/a1-elementary/plurals.html
+++ b/grammar/a1-elementary/plurals.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="BR-English is a responsive site with grammar, vocabulary, listening and reading resources from levels A1 to B2." />
-  <title>A1 Grammar Lessons and Exercises</title>
+  <title>Formação do plural – regulares e irregulares</title>
   <link rel="stylesheet" href="../../style.css" />
 </head>
 <body>
@@ -158,30 +158,17 @@
 
   <main class="hero">
     <div class="content">
-      <h1>A1 Grammar Lessons and Exercises</h1>
-      <p>Blocos gramaticais essenciais do nível A1</p>
-      <ul class="lesson-links">
-        <li><a href="to-be.html">Verbo “to be” – formas e contrações (am / is / are)</a></li>
-        <li><a href="possessives-and-pronouns.html">Pronomes pessoais do sujeito e adjetivos possessivos (I / my, you / your…)</a></li>
-        <li><a href="demonstratives.html">Demonstrativos (this, that, these, those)</a></li>
-        <li><a href="articles.html">Artigos indefinidos, definidos e ausência de artigo (a / an, the, Ø)</a></li>
-        <li><a href="plurals.html">Formação do plural – regulares e irregulares</a></li>
-        <li><a href="basic-word-order.html">Ordem básica da frase afirmativa (Sujeito + Verbo + Objeto)</a></li>
-        <li><a href="present-simple.html">Presente simples – forma afirmativa, negativa e interrogativa (do / does)</a></li>
-        <li><a href="adverbs-of-frequency.html">Advérbios de frequência (always, often, never…) e posição na frase</a></li>
-        <li><a href="object-vs-subject-pronouns.html">Pronomes objeto vs. pronomes sujeito (me / I, her / she…)</a></li>
-        <li><a href="wh-questions.html">Wh-questions – palavras interrogativas e ordem das palavras</a></li>
-        <li><a href="prepositions-place-time.html">Preposições de lugar (in, on, under…) e de tempo (at, on, in)</a></li>
-        <li><a href="imperative.html">Imperativo – ordens afirmativas e negativas</a></li>
-        <li><a href="can-cant.html">Can / can’t para habilidade, possibilidade e permissão</a></li>
-        <li><a href="present-continuous-vs-simple.html">Presente contínuo (am / is / are + -ing) vs. presente simples</a></li>
-        <li><a href="there-is-there-are.html">There is / There are + substantivos contáveis e incontáveis</a></li>
-        <li><a href="some-any.html">Some / any com substantivos contáveis e incontáveis</a></li>
-        <li><a href="past-be-and-past-simple.html">Passado do to be (was / were) e passado simples básico (verbos regulares e irregulares)</a></li>
-        <li><a href="be-going-to.html">Be going to para planos e previsões (ponte do fim do A1 para o A2)</a></li>
-        <li><a href="comparatives-and-superlatives.html">Comparativos e superlativos (older, the oldest)</a></li>
-        <li><a href="basic-conjunctions.html">Conjunções básicas (and, but, or, so, because)</a></li>
-      </ul>
+      <h1>Formação do plural – regulares e irregulares</h1>
+      <div class="tabs">
+      <button class="tab-button active" data-tab="explanation">Explanation</button>
+      <button class="tab-button" data-tab="exercises">Exercises</button>
+    </div>
+    <section id="explanation" class="tab-content active">
+      <p>Conteúdo em breve.
+    </section>
+      <section id="exercises" class="tab-content">
+        <p>Exercícios em breve.</p>
+      </section>
     </div>
   </main>
 
@@ -191,5 +178,19 @@
   </div>
 
   <script src="../../script.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const buttons = document.querySelectorAll('.tab-button');
+      const contents = document.querySelectorAll('.tab-content');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          buttons.forEach(b => b.classList.remove('active'));
+          contents.forEach(c => c.classList.remove('active'));
+          btn.classList.add('active');
+          document.getElementById(btn.dataset.tab).classList.add('active');
+        });
+      });
+    });
+  </script>
 </body>
 </html>

--- a/grammar/a1-elementary/prepositions-place-time.html
+++ b/grammar/a1-elementary/prepositions-place-time.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="BR-English is a responsive site with grammar, vocabulary, listening and reading resources from levels A1 to B2." />
-  <title>A1 Grammar Lessons and Exercises</title>
+  <title>Preposições de lugar (in, on, under…) e de tempo (at, on, in)</title>
   <link rel="stylesheet" href="../../style.css" />
 </head>
 <body>
@@ -158,30 +158,17 @@
 
   <main class="hero">
     <div class="content">
-      <h1>A1 Grammar Lessons and Exercises</h1>
-      <p>Blocos gramaticais essenciais do nível A1</p>
-      <ul class="lesson-links">
-        <li><a href="to-be.html">Verbo “to be” – formas e contrações (am / is / are)</a></li>
-        <li><a href="possessives-and-pronouns.html">Pronomes pessoais do sujeito e adjetivos possessivos (I / my, you / your…)</a></li>
-        <li><a href="demonstratives.html">Demonstrativos (this, that, these, those)</a></li>
-        <li><a href="articles.html">Artigos indefinidos, definidos e ausência de artigo (a / an, the, Ø)</a></li>
-        <li><a href="plurals.html">Formação do plural – regulares e irregulares</a></li>
-        <li><a href="basic-word-order.html">Ordem básica da frase afirmativa (Sujeito + Verbo + Objeto)</a></li>
-        <li><a href="present-simple.html">Presente simples – forma afirmativa, negativa e interrogativa (do / does)</a></li>
-        <li><a href="adverbs-of-frequency.html">Advérbios de frequência (always, often, never…) e posição na frase</a></li>
-        <li><a href="object-vs-subject-pronouns.html">Pronomes objeto vs. pronomes sujeito (me / I, her / she…)</a></li>
-        <li><a href="wh-questions.html">Wh-questions – palavras interrogativas e ordem das palavras</a></li>
-        <li><a href="prepositions-place-time.html">Preposições de lugar (in, on, under…) e de tempo (at, on, in)</a></li>
-        <li><a href="imperative.html">Imperativo – ordens afirmativas e negativas</a></li>
-        <li><a href="can-cant.html">Can / can’t para habilidade, possibilidade e permissão</a></li>
-        <li><a href="present-continuous-vs-simple.html">Presente contínuo (am / is / are + -ing) vs. presente simples</a></li>
-        <li><a href="there-is-there-are.html">There is / There are + substantivos contáveis e incontáveis</a></li>
-        <li><a href="some-any.html">Some / any com substantivos contáveis e incontáveis</a></li>
-        <li><a href="past-be-and-past-simple.html">Passado do to be (was / were) e passado simples básico (verbos regulares e irregulares)</a></li>
-        <li><a href="be-going-to.html">Be going to para planos e previsões (ponte do fim do A1 para o A2)</a></li>
-        <li><a href="comparatives-and-superlatives.html">Comparativos e superlativos (older, the oldest)</a></li>
-        <li><a href="basic-conjunctions.html">Conjunções básicas (and, but, or, so, because)</a></li>
-      </ul>
+      <h1>Preposições de lugar (in, on, under…) e de tempo (at, on, in)</h1>
+      <div class="tabs">
+      <button class="tab-button active" data-tab="explanation">Explanation</button>
+      <button class="tab-button" data-tab="exercises">Exercises</button>
+    </div>
+    <section id="explanation" class="tab-content active">
+      <p>Conteúdo em breve.
+    </section>
+      <section id="exercises" class="tab-content">
+        <p>Exercícios em breve.</p>
+      </section>
     </div>
   </main>
 
@@ -191,5 +178,19 @@
   </div>
 
   <script src="../../script.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const buttons = document.querySelectorAll('.tab-button');
+      const contents = document.querySelectorAll('.tab-content');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          buttons.forEach(b => b.classList.remove('active'));
+          contents.forEach(c => c.classList.remove('active'));
+          btn.classList.add('active');
+          document.getElementById(btn.dataset.tab).classList.add('active');
+        });
+      });
+    });
+  </script>
 </body>
 </html>

--- a/grammar/a1-elementary/present-continuous-vs-simple.html
+++ b/grammar/a1-elementary/present-continuous-vs-simple.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="BR-English is a responsive site with grammar, vocabulary, listening and reading resources from levels A1 to B2." />
-  <title>A1 Grammar Lessons and Exercises</title>
+  <title>Presente contínuo (am / is / are + -ing) vs. presente simples</title>
   <link rel="stylesheet" href="../../style.css" />
 </head>
 <body>
@@ -158,30 +158,17 @@
 
   <main class="hero">
     <div class="content">
-      <h1>A1 Grammar Lessons and Exercises</h1>
-      <p>Blocos gramaticais essenciais do nível A1</p>
-      <ul class="lesson-links">
-        <li><a href="to-be.html">Verbo “to be” – formas e contrações (am / is / are)</a></li>
-        <li><a href="possessives-and-pronouns.html">Pronomes pessoais do sujeito e adjetivos possessivos (I / my, you / your…)</a></li>
-        <li><a href="demonstratives.html">Demonstrativos (this, that, these, those)</a></li>
-        <li><a href="articles.html">Artigos indefinidos, definidos e ausência de artigo (a / an, the, Ø)</a></li>
-        <li><a href="plurals.html">Formação do plural – regulares e irregulares</a></li>
-        <li><a href="basic-word-order.html">Ordem básica da frase afirmativa (Sujeito + Verbo + Objeto)</a></li>
-        <li><a href="present-simple.html">Presente simples – forma afirmativa, negativa e interrogativa (do / does)</a></li>
-        <li><a href="adverbs-of-frequency.html">Advérbios de frequência (always, often, never…) e posição na frase</a></li>
-        <li><a href="object-vs-subject-pronouns.html">Pronomes objeto vs. pronomes sujeito (me / I, her / she…)</a></li>
-        <li><a href="wh-questions.html">Wh-questions – palavras interrogativas e ordem das palavras</a></li>
-        <li><a href="prepositions-place-time.html">Preposições de lugar (in, on, under…) e de tempo (at, on, in)</a></li>
-        <li><a href="imperative.html">Imperativo – ordens afirmativas e negativas</a></li>
-        <li><a href="can-cant.html">Can / can’t para habilidade, possibilidade e permissão</a></li>
-        <li><a href="present-continuous-vs-simple.html">Presente contínuo (am / is / are + -ing) vs. presente simples</a></li>
-        <li><a href="there-is-there-are.html">There is / There are + substantivos contáveis e incontáveis</a></li>
-        <li><a href="some-any.html">Some / any com substantivos contáveis e incontáveis</a></li>
-        <li><a href="past-be-and-past-simple.html">Passado do to be (was / were) e passado simples básico (verbos regulares e irregulares)</a></li>
-        <li><a href="be-going-to.html">Be going to para planos e previsões (ponte do fim do A1 para o A2)</a></li>
-        <li><a href="comparatives-and-superlatives.html">Comparativos e superlativos (older, the oldest)</a></li>
-        <li><a href="basic-conjunctions.html">Conjunções básicas (and, but, or, so, because)</a></li>
-      </ul>
+      <h1>Presente contínuo (am / is / are + -ing) vs. presente simples</h1>
+      <div class="tabs">
+      <button class="tab-button active" data-tab="explanation">Explanation</button>
+      <button class="tab-button" data-tab="exercises">Exercises</button>
+    </div>
+    <section id="explanation" class="tab-content active">
+      <p>Conteúdo em breve.
+    </section>
+      <section id="exercises" class="tab-content">
+        <p>Exercícios em breve.</p>
+      </section>
     </div>
   </main>
 
@@ -191,5 +178,19 @@
   </div>
 
   <script src="../../script.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const buttons = document.querySelectorAll('.tab-button');
+      const contents = document.querySelectorAll('.tab-content');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          buttons.forEach(b => b.classList.remove('active'));
+          contents.forEach(c => c.classList.remove('active'));
+          btn.classList.add('active');
+          document.getElementById(btn.dataset.tab).classList.add('active');
+        });
+      });
+    });
+  </script>
 </body>
 </html>

--- a/grammar/a1-elementary/present-simple.html
+++ b/grammar/a1-elementary/present-simple.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="BR-English is a responsive site with grammar, vocabulary, listening and reading resources from levels A1 to B2." />
-  <title>A1 Grammar Lessons and Exercises</title>
+  <title>Presente simples – forma afirmativa, negativa e interrogativa (do / does)</title>
   <link rel="stylesheet" href="../../style.css" />
 </head>
 <body>
@@ -158,30 +158,17 @@
 
   <main class="hero">
     <div class="content">
-      <h1>A1 Grammar Lessons and Exercises</h1>
-      <p>Blocos gramaticais essenciais do nível A1</p>
-      <ul class="lesson-links">
-        <li><a href="to-be.html">Verbo “to be” – formas e contrações (am / is / are)</a></li>
-        <li><a href="possessives-and-pronouns.html">Pronomes pessoais do sujeito e adjetivos possessivos (I / my, you / your…)</a></li>
-        <li><a href="demonstratives.html">Demonstrativos (this, that, these, those)</a></li>
-        <li><a href="articles.html">Artigos indefinidos, definidos e ausência de artigo (a / an, the, Ø)</a></li>
-        <li><a href="plurals.html">Formação do plural – regulares e irregulares</a></li>
-        <li><a href="basic-word-order.html">Ordem básica da frase afirmativa (Sujeito + Verbo + Objeto)</a></li>
-        <li><a href="present-simple.html">Presente simples – forma afirmativa, negativa e interrogativa (do / does)</a></li>
-        <li><a href="adverbs-of-frequency.html">Advérbios de frequência (always, often, never…) e posição na frase</a></li>
-        <li><a href="object-vs-subject-pronouns.html">Pronomes objeto vs. pronomes sujeito (me / I, her / she…)</a></li>
-        <li><a href="wh-questions.html">Wh-questions – palavras interrogativas e ordem das palavras</a></li>
-        <li><a href="prepositions-place-time.html">Preposições de lugar (in, on, under…) e de tempo (at, on, in)</a></li>
-        <li><a href="imperative.html">Imperativo – ordens afirmativas e negativas</a></li>
-        <li><a href="can-cant.html">Can / can’t para habilidade, possibilidade e permissão</a></li>
-        <li><a href="present-continuous-vs-simple.html">Presente contínuo (am / is / are + -ing) vs. presente simples</a></li>
-        <li><a href="there-is-there-are.html">There is / There are + substantivos contáveis e incontáveis</a></li>
-        <li><a href="some-any.html">Some / any com substantivos contáveis e incontáveis</a></li>
-        <li><a href="past-be-and-past-simple.html">Passado do to be (was / were) e passado simples básico (verbos regulares e irregulares)</a></li>
-        <li><a href="be-going-to.html">Be going to para planos e previsões (ponte do fim do A1 para o A2)</a></li>
-        <li><a href="comparatives-and-superlatives.html">Comparativos e superlativos (older, the oldest)</a></li>
-        <li><a href="basic-conjunctions.html">Conjunções básicas (and, but, or, so, because)</a></li>
-      </ul>
+      <h1>Presente simples – forma afirmativa, negativa e interrogativa (do / does)</h1>
+      <div class="tabs">
+      <button class="tab-button active" data-tab="explanation">Explanation</button>
+      <button class="tab-button" data-tab="exercises">Exercises</button>
+    </div>
+    <section id="explanation" class="tab-content active">
+      <p>Conteúdo em breve.
+    </section>
+      <section id="exercises" class="tab-content">
+        <p>Exercícios em breve.</p>
+      </section>
     </div>
   </main>
 
@@ -191,5 +178,19 @@
   </div>
 
   <script src="../../script.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const buttons = document.querySelectorAll('.tab-button');
+      const contents = document.querySelectorAll('.tab-content');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          buttons.forEach(b => b.classList.remove('active'));
+          contents.forEach(c => c.classList.remove('active'));
+          btn.classList.add('active');
+          document.getElementById(btn.dataset.tab).classList.add('active');
+        });
+      });
+    });
+  </script>
 </body>
 </html>

--- a/grammar/a1-elementary/some-any.html
+++ b/grammar/a1-elementary/some-any.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="BR-English is a responsive site with grammar, vocabulary, listening and reading resources from levels A1 to B2." />
-  <title>A1 Grammar Lessons and Exercises</title>
+  <title>Some / any com substantivos contáveis e incontáveis</title>
   <link rel="stylesheet" href="../../style.css" />
 </head>
 <body>
@@ -158,30 +158,17 @@
 
   <main class="hero">
     <div class="content">
-      <h1>A1 Grammar Lessons and Exercises</h1>
-      <p>Blocos gramaticais essenciais do nível A1</p>
-      <ul class="lesson-links">
-        <li><a href="to-be.html">Verbo “to be” – formas e contrações (am / is / are)</a></li>
-        <li><a href="possessives-and-pronouns.html">Pronomes pessoais do sujeito e adjetivos possessivos (I / my, you / your…)</a></li>
-        <li><a href="demonstratives.html">Demonstrativos (this, that, these, those)</a></li>
-        <li><a href="articles.html">Artigos indefinidos, definidos e ausência de artigo (a / an, the, Ø)</a></li>
-        <li><a href="plurals.html">Formação do plural – regulares e irregulares</a></li>
-        <li><a href="basic-word-order.html">Ordem básica da frase afirmativa (Sujeito + Verbo + Objeto)</a></li>
-        <li><a href="present-simple.html">Presente simples – forma afirmativa, negativa e interrogativa (do / does)</a></li>
-        <li><a href="adverbs-of-frequency.html">Advérbios de frequência (always, often, never…) e posição na frase</a></li>
-        <li><a href="object-vs-subject-pronouns.html">Pronomes objeto vs. pronomes sujeito (me / I, her / she…)</a></li>
-        <li><a href="wh-questions.html">Wh-questions – palavras interrogativas e ordem das palavras</a></li>
-        <li><a href="prepositions-place-time.html">Preposições de lugar (in, on, under…) e de tempo (at, on, in)</a></li>
-        <li><a href="imperative.html">Imperativo – ordens afirmativas e negativas</a></li>
-        <li><a href="can-cant.html">Can / can’t para habilidade, possibilidade e permissão</a></li>
-        <li><a href="present-continuous-vs-simple.html">Presente contínuo (am / is / are + -ing) vs. presente simples</a></li>
-        <li><a href="there-is-there-are.html">There is / There are + substantivos contáveis e incontáveis</a></li>
-        <li><a href="some-any.html">Some / any com substantivos contáveis e incontáveis</a></li>
-        <li><a href="past-be-and-past-simple.html">Passado do to be (was / were) e passado simples básico (verbos regulares e irregulares)</a></li>
-        <li><a href="be-going-to.html">Be going to para planos e previsões (ponte do fim do A1 para o A2)</a></li>
-        <li><a href="comparatives-and-superlatives.html">Comparativos e superlativos (older, the oldest)</a></li>
-        <li><a href="basic-conjunctions.html">Conjunções básicas (and, but, or, so, because)</a></li>
-      </ul>
+      <h1>Some / any com substantivos contáveis e incontáveis</h1>
+      <div class="tabs">
+      <button class="tab-button active" data-tab="explanation">Explanation</button>
+      <button class="tab-button" data-tab="exercises">Exercises</button>
+    </div>
+    <section id="explanation" class="tab-content active">
+      <p>Conteúdo em breve.
+    </section>
+      <section id="exercises" class="tab-content">
+        <p>Exercícios em breve.</p>
+      </section>
     </div>
   </main>
 
@@ -191,5 +178,19 @@
   </div>
 
   <script src="../../script.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const buttons = document.querySelectorAll('.tab-button');
+      const contents = document.querySelectorAll('.tab-content');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          buttons.forEach(b => b.classList.remove('active'));
+          contents.forEach(c => c.classList.remove('active'));
+          btn.classList.add('active');
+          document.getElementById(btn.dataset.tab).classList.add('active');
+        });
+      });
+    });
+  </script>
 </body>
 </html>

--- a/grammar/a1-elementary/there-is-there-are.html
+++ b/grammar/a1-elementary/there-is-there-are.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="BR-English is a responsive site with grammar, vocabulary, listening and reading resources from levels A1 to B2." />
-  <title>A1 Grammar Lessons and Exercises</title>
+  <title>There is / There are + substantivos contáveis e incontáveis</title>
   <link rel="stylesheet" href="../../style.css" />
 </head>
 <body>
@@ -158,30 +158,17 @@
 
   <main class="hero">
     <div class="content">
-      <h1>A1 Grammar Lessons and Exercises</h1>
-      <p>Blocos gramaticais essenciais do nível A1</p>
-      <ul class="lesson-links">
-        <li><a href="to-be.html">Verbo “to be” – formas e contrações (am / is / are)</a></li>
-        <li><a href="possessives-and-pronouns.html">Pronomes pessoais do sujeito e adjetivos possessivos (I / my, you / your…)</a></li>
-        <li><a href="demonstratives.html">Demonstrativos (this, that, these, those)</a></li>
-        <li><a href="articles.html">Artigos indefinidos, definidos e ausência de artigo (a / an, the, Ø)</a></li>
-        <li><a href="plurals.html">Formação do plural – regulares e irregulares</a></li>
-        <li><a href="basic-word-order.html">Ordem básica da frase afirmativa (Sujeito + Verbo + Objeto)</a></li>
-        <li><a href="present-simple.html">Presente simples – forma afirmativa, negativa e interrogativa (do / does)</a></li>
-        <li><a href="adverbs-of-frequency.html">Advérbios de frequência (always, often, never…) e posição na frase</a></li>
-        <li><a href="object-vs-subject-pronouns.html">Pronomes objeto vs. pronomes sujeito (me / I, her / she…)</a></li>
-        <li><a href="wh-questions.html">Wh-questions – palavras interrogativas e ordem das palavras</a></li>
-        <li><a href="prepositions-place-time.html">Preposições de lugar (in, on, under…) e de tempo (at, on, in)</a></li>
-        <li><a href="imperative.html">Imperativo – ordens afirmativas e negativas</a></li>
-        <li><a href="can-cant.html">Can / can’t para habilidade, possibilidade e permissão</a></li>
-        <li><a href="present-continuous-vs-simple.html">Presente contínuo (am / is / are + -ing) vs. presente simples</a></li>
-        <li><a href="there-is-there-are.html">There is / There are + substantivos contáveis e incontáveis</a></li>
-        <li><a href="some-any.html">Some / any com substantivos contáveis e incontáveis</a></li>
-        <li><a href="past-be-and-past-simple.html">Passado do to be (was / were) e passado simples básico (verbos regulares e irregulares)</a></li>
-        <li><a href="be-going-to.html">Be going to para planos e previsões (ponte do fim do A1 para o A2)</a></li>
-        <li><a href="comparatives-and-superlatives.html">Comparativos e superlativos (older, the oldest)</a></li>
-        <li><a href="basic-conjunctions.html">Conjunções básicas (and, but, or, so, because)</a></li>
-      </ul>
+      <h1>There is / There are + substantivos contáveis e incontáveis</h1>
+      <div class="tabs">
+      <button class="tab-button active" data-tab="explanation">Explanation</button>
+      <button class="tab-button" data-tab="exercises">Exercises</button>
+    </div>
+    <section id="explanation" class="tab-content active">
+      <p>Conteúdo em breve.
+    </section>
+      <section id="exercises" class="tab-content">
+        <p>Exercícios em breve.</p>
+      </section>
     </div>
   </main>
 
@@ -191,5 +178,19 @@
   </div>
 
   <script src="../../script.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const buttons = document.querySelectorAll('.tab-button');
+      const contents = document.querySelectorAll('.tab-content');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          buttons.forEach(b => b.classList.remove('active'));
+          contents.forEach(c => c.classList.remove('active'));
+          btn.classList.add('active');
+          document.getElementById(btn.dataset.tab).classList.add('active');
+        });
+      });
+    });
+  </script>
 </body>
 </html>

--- a/grammar/a1-elementary/to-be.html
+++ b/grammar/a1-elementary/to-be.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="BR-English is a responsive site with grammar, vocabulary, listening and reading resources from levels A1 to B2." />
-  <title>Formas simples do verbo to be</title>
+  <title>Verbo “to be” – formas e contrações (am / is / are)</title>
   <link rel="stylesheet" href="../../style.css" />
 </head>
 <body>
@@ -158,7 +158,7 @@
 
   <main class="hero">
     <div class="content">
-      <h1 class="lesson-title">Formas simples do verbo to be</h1>
+      <h1 class="lesson-title">Verbo “to be” – formas e contrações (am / is / are)</h1>
       <div class="tabs">
       <button class="tab-button active" data-tab="explanation">Explanation</button>
       <button class="tab-button" data-tab="exercises">Examples</button>

--- a/grammar/a1-elementary/wh-questions.html
+++ b/grammar/a1-elementary/wh-questions.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="BR-English is a responsive site with grammar, vocabulary, listening and reading resources from levels A1 to B2." />
-  <title>A1 Grammar Lessons and Exercises</title>
+  <title>Wh-questions – palavras interrogativas e ordem das palavras</title>
   <link rel="stylesheet" href="../../style.css" />
 </head>
 <body>
@@ -158,30 +158,17 @@
 
   <main class="hero">
     <div class="content">
-      <h1>A1 Grammar Lessons and Exercises</h1>
-      <p>Blocos gramaticais essenciais do nível A1</p>
-      <ul class="lesson-links">
-        <li><a href="to-be.html">Verbo “to be” – formas e contrações (am / is / are)</a></li>
-        <li><a href="possessives-and-pronouns.html">Pronomes pessoais do sujeito e adjetivos possessivos (I / my, you / your…)</a></li>
-        <li><a href="demonstratives.html">Demonstrativos (this, that, these, those)</a></li>
-        <li><a href="articles.html">Artigos indefinidos, definidos e ausência de artigo (a / an, the, Ø)</a></li>
-        <li><a href="plurals.html">Formação do plural – regulares e irregulares</a></li>
-        <li><a href="basic-word-order.html">Ordem básica da frase afirmativa (Sujeito + Verbo + Objeto)</a></li>
-        <li><a href="present-simple.html">Presente simples – forma afirmativa, negativa e interrogativa (do / does)</a></li>
-        <li><a href="adverbs-of-frequency.html">Advérbios de frequência (always, often, never…) e posição na frase</a></li>
-        <li><a href="object-vs-subject-pronouns.html">Pronomes objeto vs. pronomes sujeito (me / I, her / she…)</a></li>
-        <li><a href="wh-questions.html">Wh-questions – palavras interrogativas e ordem das palavras</a></li>
-        <li><a href="prepositions-place-time.html">Preposições de lugar (in, on, under…) e de tempo (at, on, in)</a></li>
-        <li><a href="imperative.html">Imperativo – ordens afirmativas e negativas</a></li>
-        <li><a href="can-cant.html">Can / can’t para habilidade, possibilidade e permissão</a></li>
-        <li><a href="present-continuous-vs-simple.html">Presente contínuo (am / is / are + -ing) vs. presente simples</a></li>
-        <li><a href="there-is-there-are.html">There is / There are + substantivos contáveis e incontáveis</a></li>
-        <li><a href="some-any.html">Some / any com substantivos contáveis e incontáveis</a></li>
-        <li><a href="past-be-and-past-simple.html">Passado do to be (was / were) e passado simples básico (verbos regulares e irregulares)</a></li>
-        <li><a href="be-going-to.html">Be going to para planos e previsões (ponte do fim do A1 para o A2)</a></li>
-        <li><a href="comparatives-and-superlatives.html">Comparativos e superlativos (older, the oldest)</a></li>
-        <li><a href="basic-conjunctions.html">Conjunções básicas (and, but, or, so, because)</a></li>
-      </ul>
+      <h1>Wh-questions – palavras interrogativas e ordem das palavras</h1>
+      <div class="tabs">
+      <button class="tab-button active" data-tab="explanation">Explanation</button>
+      <button class="tab-button" data-tab="exercises">Exercises</button>
+    </div>
+    <section id="explanation" class="tab-content active">
+      <p>Conteúdo em breve.
+    </section>
+      <section id="exercises" class="tab-content">
+        <p>Exercícios em breve.</p>
+      </section>
     </div>
   </main>
 
@@ -191,5 +178,19 @@
   </div>
 
   <script src="../../script.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const buttons = document.querySelectorAll('.tab-button');
+      const contents = document.querySelectorAll('.tab-content');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          buttons.forEach(b => b.classList.remove('active'));
+          contents.forEach(c => c.classList.remove('active'));
+          btn.classList.add('active');
+          document.getElementById(btn.dataset.tab).classList.add('active');
+        });
+      });
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rename lesson title for `to-be` page
- link all A1 grammar topics to new placeholder pages
- add placeholder pages for upcoming lessons

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6855a9eb51c0832394e998555d8cd8c9