### PR TITLE
Fix grammar A2 links

### DIFF
--- a/grammar/a1-elementary/adverbs-of-frequency.html
+++ b/grammar/a1-elementary/adverbs-of-frequency.html
@@ -35,7 +35,7 @@
               </a>
             </li>
             <li role="none">
-              <a role="menuitem" href="#">
+              <a role="menuitem" href="../a2-pre-intermediate/index.html">
                 <span class="level-circle level-a2">A2</span> Pre-intermediate
               </a>
             </li>

--- a/grammar/a1-elementary/articles.html
+++ b/grammar/a1-elementary/articles.html
@@ -35,7 +35,7 @@
               </a>
             </li>
             <li role="none">
-              <a role="menuitem" href="#">
+              <a role="menuitem" href="../a2-pre-intermediate/index.html">
                 <span class="level-circle level-a2">A2</span> Pre-intermediate
               </a>
             </li>

--- a/grammar/a1-elementary/basic-conjunctions.html
+++ b/grammar/a1-elementary/basic-conjunctions.html
@@ -35,7 +35,7 @@
               </a>
             </li>
             <li role="none">
-              <a role="menuitem" href="#">
+              <a role="menuitem" href="../a2-pre-intermediate/index.html">
                 <span class="level-circle level-a2">A2</span> Pre-intermediate
               </a>
             </li>

--- a/grammar/a1-elementary/basic-word-order.html
+++ b/grammar/a1-elementary/basic-word-order.html
@@ -35,7 +35,7 @@
               </a>
             </li>
             <li role="none">
-              <a role="menuitem" href="#">
+              <a role="menuitem" href="../a2-pre-intermediate/index.html">
                 <span class="level-circle level-a2">A2</span> Pre-intermediate
               </a>
             </li>

--- a/grammar/a1-elementary/be-going-to.html
+++ b/grammar/a1-elementary/be-going-to.html
@@ -35,7 +35,7 @@
               </a>
             </li>
             <li role="none">
-              <a role="menuitem" href="#">
+              <a role="menuitem" href="../a2-pre-intermediate/index.html">
                 <span class="level-circle level-a2">A2</span> Pre-intermediate
               </a>
             </li>

--- a/grammar/a1-elementary/can-cant.html
+++ b/grammar/a1-elementary/can-cant.html
@@ -35,7 +35,7 @@
               </a>
             </li>
             <li role="none">
-              <a role="menuitem" href="#">
+              <a role="menuitem" href="../a2-pre-intermediate/index.html">
                 <span class="level-circle level-a2">A2</span> Pre-intermediate
               </a>
             </li>

--- a/grammar/a1-elementary/comparatives-and-superlatives.html
+++ b/grammar/a1-elementary/comparatives-and-superlatives.html
@@ -35,7 +35,7 @@
               </a>
             </li>
             <li role="none">
-              <a role="menuitem" href="#">
+              <a role="menuitem" href="../a2-pre-intermediate/index.html">
                 <span class="level-circle level-a2">A2</span> Pre-intermediate
               </a>
             </li>

--- a/grammar/a1-elementary/demonstratives.html
+++ b/grammar/a1-elementary/demonstratives.html
@@ -35,7 +35,7 @@
               </a>
             </li>
             <li role="none">
-              <a role="menuitem" href="#">
+              <a role="menuitem" href="../a2-pre-intermediate/index.html">
                 <span class="level-circle level-a2">A2</span> Pre-intermediate
               </a>
             </li>

--- a/grammar/a1-elementary/imperative.html
+++ b/grammar/a1-elementary/imperative.html
@@ -35,7 +35,7 @@
               </a>
             </li>
             <li role="none">
-              <a role="menuitem" href="#">
+              <a role="menuitem" href="../a2-pre-intermediate/index.html">
                 <span class="level-circle level-a2">A2</span> Pre-intermediate
               </a>
             </li>

--- a/grammar/a1-elementary/index.html
+++ b/grammar/a1-elementary/index.html
@@ -35,12 +35,12 @@
               </a>
             </li>
             <li role="none">
-              <a role="menuitem" href="#">
+              <a role="menuitem" href="../a2-pre-intermediate/index.html">
                 <span class="level-circle level-a2">A2</span> Pre-intermediate
               </a>
             </li>
             <li role="none">
-              <a role="menuitem" href="#">
+              <a role="menuitem" href="../a2-pre-intermediate/index.html">
                 <span class="level-circle level-b1">B1</span> Intermediate
               </a>
             </li>

--- a/grammar/a1-elementary/object-vs-subject-pronouns.html
+++ b/grammar/a1-elementary/object-vs-subject-pronouns.html
@@ -35,7 +35,7 @@
               </a>
             </li>
             <li role="none">
-              <a role="menuitem" href="#">
+              <a role="menuitem" href="../a2-pre-intermediate/index.html">
                 <span class="level-circle level-a2">A2</span> Pre-intermediate
               </a>
             </li>

--- a/grammar/a1-elementary/past-be-and-past-simple.html
+++ b/grammar/a1-elementary/past-be-and-past-simple.html
@@ -35,7 +35,7 @@
               </a>
             </li>
             <li role="none">
-              <a role="menuitem" href="#">
+              <a role="menuitem" href="../a2-pre-intermediate/index.html">
                 <span class="level-circle level-a2">A2</span> Pre-intermediate
               </a>
             </li>

--- a/grammar/a1-elementary/plurals.html
+++ b/grammar/a1-elementary/plurals.html
@@ -35,7 +35,7 @@
               </a>
             </li>
             <li role="none">
-              <a role="menuitem" href="#">
+              <a role="menuitem" href="../a2-pre-intermediate/index.html">
                 <span class="level-circle level-a2">A2</span> Pre-intermediate
               </a>
             </li>

--- a/grammar/a1-elementary/possessives-and-pronouns.html
+++ b/grammar/a1-elementary/possessives-and-pronouns.html
@@ -35,7 +35,7 @@
               </a>
             </li>
             <li role="none">
-              <a role="menuitem" href="#">
+              <a role="menuitem" href="../a2-pre-intermediate/index.html">
                 <span class="level-circle level-a2">A2</span> Pre-intermediate
               </a>
             </li>

--- a/grammar/a1-elementary/prepositions-place-time.html
+++ b/grammar/a1-elementary/prepositions-place-time.html
@@ -35,7 +35,7 @@
               </a>
             </li>
             <li role="none">
-              <a role="menuitem" href="#">
+              <a role="menuitem" href="../a2-pre-intermediate/index.html">
                 <span class="level-circle level-a2">A2</span> Pre-intermediate
               </a>
             </li>

--- a/grammar/a1-elementary/present-continuous-vs-simple.html
+++ b/grammar/a1-elementary/present-continuous-vs-simple.html
@@ -35,7 +35,7 @@
               </a>
             </li>
             <li role="none">
-              <a role="menuitem" href="#">
+              <a role="menuitem" href="../a2-pre-intermediate/index.html">
                 <span class="level-circle level-a2">A2</span> Pre-intermediate
               </a>
             </li>

--- a/grammar/a1-elementary/present-simple.html
+++ b/grammar/a1-elementary/present-simple.html
@@ -35,7 +35,7 @@
               </a>
             </li>
             <li role="none">
-              <a role="menuitem" href="#">
+              <a role="menuitem" href="../a2-pre-intermediate/index.html">
                 <span class="level-circle level-a2">A2</span> Pre-intermediate
               </a>
             </li>

--- a/grammar/a1-elementary/some-any.html
+++ b/grammar/a1-elementary/some-any.html
@@ -35,7 +35,7 @@
               </a>
             </li>
             <li role="none">
-              <a role="menuitem" href="#">
+              <a role="menuitem" href="../a2-pre-intermediate/index.html">
                 <span class="level-circle level-a2">A2</span> Pre-intermediate
               </a>
             </li>

--- a/grammar/a1-elementary/there-is-there-are.html
+++ b/grammar/a1-elementary/there-is-there-are.html
@@ -35,7 +35,7 @@
               </a>
             </li>
             <li role="none">
-              <a role="menuitem" href="#">
+              <a role="menuitem" href="../a2-pre-intermediate/index.html">
                 <span class="level-circle level-a2">A2</span> Pre-intermediate
               </a>
             </li>

--- a/grammar/a1-elementary/to-be.html
+++ b/grammar/a1-elementary/to-be.html
@@ -35,7 +35,7 @@
               </a>
             </li>
             <li role="none">
-              <a role="menuitem" href="#">
+              <a role="menuitem" href="../a2-pre-intermediate/index.html">
                 <span class="level-circle level-a2">A2</span> Pre-intermediate
               </a>
             </li>

--- a/grammar/a1-elementary/wh-questions.html
+++ b/grammar/a1-elementary/wh-questions.html
@@ -35,7 +35,7 @@
               </a>
             </li>
             <li role="none">
-              <a role="menuitem" href="#">
+              <a role="menuitem" href="../a2-pre-intermediate/index.html">
                 <span class="level-circle level-a2">A2</span> Pre-intermediate
               </a>
             </li>

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
               </a>
             </li>
             <li role="none">
-              <a role="menuitem" href="#">
+              <a role="menuitem" href="grammar/a2-pre-intermediate/index.html">
                 <span class="level-circle level-a2">A2</span> Pre-intermediate
               </a>
             </li>


### PR DESCRIPTION
## Summary
- update the A2 dropdown link in `index.html`
- fix relative A2 dropdown links on all A1 grammar pages

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6855adbeee848323a27e700310ee9834