### PR TITLE
Update A1 grammar tabs to Examples

### DIFF
--- a/grammar/a1-elementary/adverbs-of-frequency.html
+++ b/grammar/a1-elementary/adverbs-of-frequency.html
@@ -161,7 +161,7 @@
       <h1>Advérbios de frequência (always, often, never…) e posição na frase</h1>
       <div class="tabs">
       <button class="tab-button active" data-tab="explanation">Explanation</button>
-      <button class="tab-button" data-tab="exercises">Exercises</button>
+      <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
     <section id="explanation" class="tab-content active">
       <p>Conteúdo em breve.

--- a/grammar/a1-elementary/articles.html
+++ b/grammar/a1-elementary/articles.html
@@ -161,7 +161,7 @@
       <h1>Artigos indefinidos, definidos e ausência de artigo (a / an, the, Ø)</h1>
       <div class="tabs">
       <button class="tab-button active" data-tab="explanation">Explanation</button>
-      <button class="tab-button" data-tab="exercises">Exercises</button>
+      <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
     <section id="explanation" class="tab-content active">
       <p>Conteúdo em breve.

--- a/grammar/a1-elementary/basic-adjectives.html
+++ b/grammar/a1-elementary/basic-adjectives.html
@@ -161,7 +161,7 @@
       <h1>Adjetivos básicos (old, interesting, expensive, etc.)</h1>
       <div class="tabs">
       <button class="tab-button active" data-tab="explanation">Explanation</button>
-      <button class="tab-button" data-tab="exercises">Exercises</button>
+      <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
     <section id="explanation" class="tab-content active">
       <p>Conteúdo em breve.

--- a/grammar/a1-elementary/basic-conjunctions.html
+++ b/grammar/a1-elementary/basic-conjunctions.html
@@ -161,7 +161,7 @@
       <h1>Conjunções básicas (and, but, or, so, because)</h1>
       <div class="tabs">
       <button class="tab-button active" data-tab="explanation">Explanation</button>
-      <button class="tab-button" data-tab="exercises">Exercises</button>
+      <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
     <section id="explanation" class="tab-content active">
       <p>Conteúdo em breve.

--- a/grammar/a1-elementary/basic-word-order.html
+++ b/grammar/a1-elementary/basic-word-order.html
@@ -161,7 +161,7 @@
       <h1>Ordem básica da frase afirmativa (Sujeito + Verbo + Objeto)</h1>
       <div class="tabs">
       <button class="tab-button active" data-tab="explanation">Explanation</button>
-      <button class="tab-button" data-tab="exercises">Exercises</button>
+      <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
     <section id="explanation" class="tab-content active">
       <p>Conteúdo em breve.

--- a/grammar/a1-elementary/be-going-to.html
+++ b/grammar/a1-elementary/be-going-to.html
@@ -161,7 +161,7 @@
       <h1>Be going to para planos e previsões (ponte do fim do A1 para o A2)</h1>
       <div class="tabs">
       <button class="tab-button active" data-tab="explanation">Explanation</button>
-      <button class="tab-button" data-tab="exercises">Exercises</button>
+      <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
     <section id="explanation" class="tab-content active">
       <p>Conteúdo em breve.

--- a/grammar/a1-elementary/can-cant.html
+++ b/grammar/a1-elementary/can-cant.html
@@ -161,7 +161,7 @@
       <h1>Can / can’t para habilidade, possibilidade e permissão</h1>
       <div class="tabs">
       <button class="tab-button active" data-tab="explanation">Explanation</button>
-      <button class="tab-button" data-tab="exercises">Exercises</button>
+      <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
     <section id="explanation" class="tab-content active">
       <p>Conteúdo em breve.

--- a/grammar/a1-elementary/comparatives-and-superlatives.html
+++ b/grammar/a1-elementary/comparatives-and-superlatives.html
@@ -161,7 +161,7 @@
       <h1>Comparativos e superlativos (older, the oldest)</h1>
       <div class="tabs">
       <button class="tab-button active" data-tab="explanation">Explanation</button>
-      <button class="tab-button" data-tab="exercises">Exercises</button>
+      <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
     <section id="explanation" class="tab-content active">
       <p>Conteúdo em breve.

--- a/grammar/a1-elementary/have-got.html
+++ b/grammar/a1-elementary/have-got.html
@@ -161,7 +161,7 @@
       <h1>Have got</h1>
       <div class="tabs">
       <button class="tab-button active" data-tab="explanation">Explanation</button>
-      <button class="tab-button" data-tab="exercises">Exercises</button>
+      <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
     <section id="explanation" class="tab-content active">
       <p>Conteúdo em breve.

--- a/grammar/a1-elementary/imperative.html
+++ b/grammar/a1-elementary/imperative.html
@@ -161,7 +161,7 @@
       <h1>Imperativo – ordens afirmativas e negativas</h1>
       <div class="tabs">
       <button class="tab-button active" data-tab="explanation">Explanation</button>
-      <button class="tab-button" data-tab="exercises">Exercises</button>
+      <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
     <section id="explanation" class="tab-content active">
       <p>Conteúdo em breve.

--- a/grammar/a1-elementary/object-vs-subject-pronouns.html
+++ b/grammar/a1-elementary/object-vs-subject-pronouns.html
@@ -161,7 +161,7 @@
       <h1>Pronomes objeto vs. pronomes sujeito (me / I, her / she…)</h1>
       <div class="tabs">
       <button class="tab-button active" data-tab="explanation">Explanation</button>
-      <button class="tab-button" data-tab="exercises">Exercises</button>
+      <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
     <section id="explanation" class="tab-content active">
       <p>Conteúdo em breve.

--- a/grammar/a1-elementary/past-be-and-past-simple.html
+++ b/grammar/a1-elementary/past-be-and-past-simple.html
@@ -161,7 +161,7 @@
       <h1>Passado do to be (was / were) e passado simples básico (verbos regulares e irregulares)</h1>
       <div class="tabs">
       <button class="tab-button active" data-tab="explanation">Explanation</button>
-      <button class="tab-button" data-tab="exercises">Exercises</button>
+      <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
     <section id="explanation" class="tab-content active">
       <p>Conteúdo em breve.

--- a/grammar/a1-elementary/plurals.html
+++ b/grammar/a1-elementary/plurals.html
@@ -161,7 +161,7 @@
       <h1>Formação do plural – regulares e irregulares</h1>
       <div class="tabs">
       <button class="tab-button active" data-tab="explanation">Explanation</button>
-      <button class="tab-button" data-tab="exercises">Exercises</button>
+      <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
     <section id="explanation" class="tab-content active">
       <p>Conteúdo em breve.

--- a/grammar/a1-elementary/prepositions-place-time.html
+++ b/grammar/a1-elementary/prepositions-place-time.html
@@ -161,7 +161,7 @@
       <h1>Preposições de lugar (in, on, under…) e de tempo (at, on, in)</h1>
       <div class="tabs">
       <button class="tab-button active" data-tab="explanation">Explanation</button>
-      <button class="tab-button" data-tab="exercises">Exercises</button>
+      <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
     <section id="explanation" class="tab-content active">
       <p>Conteúdo em breve.

--- a/grammar/a1-elementary/present-continuous-vs-simple.html
+++ b/grammar/a1-elementary/present-continuous-vs-simple.html
@@ -161,7 +161,7 @@
       <h1>Presente contínuo (am / is / are + -ing) vs. presente simples</h1>
       <div class="tabs">
       <button class="tab-button active" data-tab="explanation">Explanation</button>
-      <button class="tab-button" data-tab="exercises">Exercises</button>
+      <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
     <section id="explanation" class="tab-content active">
       <p>Conteúdo em breve.

--- a/grammar/a1-elementary/present-simple.html
+++ b/grammar/a1-elementary/present-simple.html
@@ -161,7 +161,7 @@
       <h1>Presente simples – forma afirmativa, negativa e interrogativa (do / does)</h1>
       <div class="tabs">
       <button class="tab-button active" data-tab="explanation">Explanation</button>
-      <button class="tab-button" data-tab="exercises">Exercises</button>
+      <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
     <section id="explanation" class="tab-content active">
       <p>Conteúdo em breve.

--- a/grammar/a1-elementary/some-any.html
+++ b/grammar/a1-elementary/some-any.html
@@ -161,7 +161,7 @@
       <h1>Some / any com substantivos contáveis e incontáveis</h1>
       <div class="tabs">
       <button class="tab-button active" data-tab="explanation">Explanation</button>
-      <button class="tab-button" data-tab="exercises">Exercises</button>
+      <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
     <section id="explanation" class="tab-content active">
       <p>Conteúdo em breve.

--- a/grammar/a1-elementary/there-is-there-are.html
+++ b/grammar/a1-elementary/there-is-there-are.html
@@ -161,7 +161,7 @@
       <h1>There is / There are + substantivos contáveis e incontáveis</h1>
       <div class="tabs">
       <button class="tab-button active" data-tab="explanation">Explanation</button>
-      <button class="tab-button" data-tab="exercises">Exercises</button>
+      <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
     <section id="explanation" class="tab-content active">
       <p>Conteúdo em breve.

--- a/grammar/a1-elementary/there-or-it.html
+++ b/grammar/a1-elementary/there-or-it.html
@@ -161,7 +161,7 @@
       <h1>There or It</h1>
       <div class="tabs">
       <button class="tab-button active" data-tab="explanation">Explanation</button>
-      <button class="tab-button" data-tab="exercises">Exercises</button>
+      <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
     <section id="explanation" class="tab-content active">
       <p>Conteúdo em breve.

--- a/grammar/a1-elementary/wh-questions.html
+++ b/grammar/a1-elementary/wh-questions.html
@@ -161,7 +161,7 @@
       <h1>Wh-questions – palavras interrogativas e ordem das palavras</h1>
       <div class="tabs">
       <button class="tab-button active" data-tab="explanation">Explanation</button>
-      <button class="tab-button" data-tab="exercises">Exercises</button>
+      <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
     <section id="explanation" class="tab-content active">
       <p>Conteúdo em breve.

--- a/grammar/a1-elementary/whose-possessive-s.html
+++ b/grammar/a1-elementary/whose-possessive-s.html
@@ -161,7 +161,7 @@
       <h1>Whose e possessivo 's (Whose is this? It’s Mike’s)</h1>
       <div class="tabs">
       <button class="tab-button active" data-tab="explanation">Explanation</button>
-      <button class="tab-button" data-tab="exercises">Exercises</button>
+      <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
     <section id="explanation" class="tab-content active">
       <p>Conteúdo em breve.

--- a/grammar/a1-elementary/would-you-like.html
+++ b/grammar/a1-elementary/would-you-like.html
@@ -161,7 +161,7 @@
       <h1>Would you like...? I’d like...</h1>
       <div class="tabs">
       <button class="tab-button active" data-tab="explanation">Explanation</button>
-      <button class="tab-button" data-tab="exercises">Exercises</button>
+      <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
     <section id="explanation" class="tab-content active">
       <p>Conteúdo em breve.


### PR DESCRIPTION
## Summary
- rename *Exercises* tab to *Examples* in all level A1 grammar pages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68587423f51083239d18cb17af84ca3e