### PR TITLE
Fix plural link

### DIFF
--- a/grammar/a1-elementary/index.html
+++ b/grammar/a1-elementary/index.html
@@ -164,7 +164,7 @@
         <li><a href="to-be.html">Present simple forms of “to be": am / is / are</a></li>
         <li><a href="demonstratives.html">This, that, these, those</a></li>
         <li><a href="possessives-and-pronouns.html">Possessive adjectives and subject pronouns (I/my, you/your, etc.)</a></li>
-        <li><a href="articles.html">A/an, plurals: singular and plural forms</a></li>
+        <li><a href="plurals.html">A/an, plurals: singular and plural forms</a></li>
         <li><a href="basic-adjectives.html">Adjectives: old, interesting, expensive, etc.</a></li>
         <li><a href="present-simple.html">Present simple: I do, I don’t, Do I?</a></li>
         <li><a href="wh-questions.html">Questions: word order and question words</a></li>


### PR DESCRIPTION
## Summary
- fix broken link on A1 grammar index to go to `plurals.html`

## Testing
- `grep -n "A/an, plurals" -n grammar/a1-elementary/index.html`

------
https://chatgpt.com/codex/tasks/task_e_6859b5fc6e1c832385dae69fff67258f