### PR TITLE
Fix headings for present simple lesson

### DIFF
--- a/grammar/a1-elementary/present-simple-forms-of-to-be-am-is-are.html
+++ b/grammar/a1-elementary/present-simple-forms-of-to-be-am-is-are.html
@@ -158,15 +158,16 @@
 
   <main class="hero">
     <div class="content">
-      <h1 class="lesson-title">Present simple forms of “to be”: am / is / are</h1>
+      <h1>Present simple forms of “to be”: am / is / are</h1>
       <div class="tabs">
       <button class="tab-button active" data-tab="explanation">Explanation</button>
       <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
       <section id="explanation" class="tab-content active">
+        <h3>Visão Geral</h3>
         <p>A seguir, você encontra todas as formas do verbo <em>to be</em> no presente simples, organizadas em afirmativa, negativa, interrogativa e respostas curtas.</p>
 
-        <h3>1. Formas afirmativa, negativa e interrogativa</h3>
+        <h3>Form</h3>
 <table class="simple-table">
   <thead>
     <tr>
@@ -214,7 +215,7 @@
   </tbody>
 </table>
 
-<h3>2. Respostas Curtas (Short Answers)</h3>
+<h3>Respostas curtas (Short Answers)</h3>
         <table class="simple-table">
           <thead>
             <tr>
@@ -271,7 +272,7 @@
           </div>
         </div>
 
-        <h3>3. Using the verb to be</h3>
+        <h3>Using the verb to be</h3>
         <h4 class="intro-heading">The present simple of the verb be has three forms:</h4>
         <div class="forms-box">
           <ul>
@@ -324,7 +325,7 @@
           <p>Yes, they are.<span class="correct"></span><br />Yes, they're.<span class="incorrect"></span></p>
         </div>
 
-        <h3>4. The present simple of be – USE</h3>
+        <h3>The present simple of be – USE</h3>
         <h4 class="section-subtitle">Different uses of BE</h4>
         <table class="simple-table">
           <thead>


### PR DESCRIPTION
## Summary
- tweak headings in the *present simple forms of to be* lesson to match the layout of other pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b3312cc9883238ec9d6c665531391