### PR TITLE
Organize A1 grammar page by modules

### DIFF
--- a/grammar/a1-elementary/index.html
+++ b/grammar/a1-elementary/index.html
@@ -160,44 +160,104 @@
     <div class="content">
       <h1>A1 Grammar Lessons and Examples</h1>
       <p>Blocos gramaticais essenciais do nível A1</p>
-      <ul class="lesson-links">
-        <li><a href="present-simple-forms-of-to-be-am-is-are.html">Present simple forms of “to be": am / is / are</a></li>
-        <li><a href="this-that-these-those.html">This, that, these, those</a></li>
-        <li><a href="possessive-adjectives-and-subject-pronouns-i-my-you-your-etc.html">Possessive adjectives and subject pronouns (I/my, you/your, etc.)</a></li>
-        <li><a href="a-an-the-no-article-the-use-of-articles-in-english.html">A/an, plurals: singular and plural forms</a></li>
-        <li><a href="adjectives-old-interesting-expensive-etc.html">Adjectives: old, interesting, expensive, etc.</a></li>
-        <li><a href="present-simple-i-do-i-dont-do-i.html">Present simple: I do, I don’t, Do I?</a></li>
-        <li><a href="questions-word-order-and-question-words.html">Questions: word order and question words</a></li>
-        <li><a href="adverbs-of-frequency-with-present-simple.html">Adverbs of frequency with present simple</a></li>
-        <li><a href="object-pronouns-vs-subject-pronouns-me-or-i-she-or-her.html">Object pronouns vs. subject pronouns: me or I, she or her?</a></li>
-        <li><a href="whose-possessive-s-whose-is-this-its-mikes.html">Whose, possessive ’s: Whose is this? It’s Mike’s</a></li>
-        <li><a href="at-in-on-prepositions-of-time.html">At, in, on: prepositions of time</a></li>
-        <li><a href="at-in-on-prepositions-of-time.html">At, in, on: prepositions of place</a></li>
-        <li><a href="can-cant-ability-possibility-permission.html">Can, can’t: ability, possibility, permission</a></li>
-        <li><a href="present-simple-or-present-continuous.html">Present continuous: I’m doing, I’m not doing, Are you doing?</a></li>
-        <li><a href="present-simple-or-present-continuous.html">Present simple or present continuous?</a></li>
-        <li><a href="the-imperative-sit-down-dont-talk.html">The imperative: Sit down! Don’t talk!</a></li>
-        <li><a href="was-were-past-simple-of-be.html">Was / were: past simple of be</a></li>
-        <li><a href="was-were-past-simple-of-be.html">Past simple: regular / irregular verbs</a></li>
-        <li><a href="was-were-past-simple-of-be.html">Past simple: negatives and questions</a></li>
-        <li><a href="../a2-pre-intermediate/gerunds-and-infinitives.html">Verbs + to + infinitive and verbs + -ing</a></li>
-        <li><a href="would-you-like-id-like.html">Would you like…? I’d like…</a></li>
-        <li><a href="have-got.html">Have got</a></li>
-        <li><a href="a-some-any-countable-and-uncountable-nouns.html">A, some, any: countable and uncountable nouns</a></li>
-        <li><a href="there-is-there-are-there-was-there-were.html">There is, there are / there was, there were</a></li>
-        <li><a href="there-or-it.html">There or It</a></li>
-        <li><a href="at-in-on-prepositions-of-time.html">Next to, under, between, in front of, behind, over, etc.</a></li>
-        <li><a href="../a2-pre-intermediate/quantifiers-much-many-a-lot.html">Much, many, a lot of, a little, a few</a></li>
-        <li><a href="comparative-adjectives-older-than-more-important-than-etc.html">Comparative adjectives: older than, more important than, etc.</a></li>
-        <li><a href="comparative-adjectives-older-than-more-important-than-etc.html">Superlative adjectives: the oldest, the most important, etc.</a></li>
-        <li><a href="../a2-pre-intermediate/will-for-promises-predictions.html">Will and shall: future</a></li>
-        <li><a href="be-going-to-plans-and-predictions.html">Be going to: plans and predictions</a></li>
-        <li><a href="../a2-pre-intermediate/adverbs-manner.html">Adverbs of manner (slowly) or adjectives (slow) ?</a></li>
-        <li><a href="a-an-the-no-article-the-use-of-articles-in-english.html">A/an, the, no article: the use of articles in English</a></li>
-        <li><a href="conjunctions-and-but-or-so-because.html">Conjunctions: and, but, or, so, because</a></li>
-        <li><a href="basic-word-order-in-english.html">Basic word order in English</a></li>
-        <li><a href="this-that-these-those.html">The difference between “this” and “it”</a></li>
-      </ul>
+      <div class="module" id="module1">
+        <div class="module-header">
+          <h3>Módulo 1 – Fundamentos da frase</h3>
+          <button class="module-toggle" data-target="module1-content" aria-expanded="true">Esconder conteúdo</button>
+        </div>
+        <ul class="lesson-links module-content" id="module1-content">
+          <li><a href="present-simple-forms-of-to-be-am-is-are.html">Present simple forms of “to be": am / is / are</a></li>
+          <li><a href="this-that-these-those.html">This, that, these, those</a></li>
+          <li><a href="possessive-adjectives-and-subject-pronouns-i-my-you-your-etc.html">Possessive adjectives and subject pronouns (I/my, you/your, etc.)</a></li>
+          <li><a href="a-an-plurals-singular-and-plural-forms.html">A/an, plurals: singular and plural forms</a></li>
+          <li><a href="adjectives-old-interesting-expensive-etc.html">Adjectives: old, interesting, expensive, etc.</a></li>
+          <li><a href="basic-word-order-in-english.html">Basic word order in English</a></li>
+        </ul>
+      </div>
+
+      <div class="module" id="module2">
+        <div class="module-header">
+          <h3>Módulo 2 – Estruturando frases no presente</h3>
+          <button class="module-toggle" data-target="module2-content" aria-expanded="true">Esconder conteúdo</button>
+        </div>
+        <ul class="lesson-links module-content" id="module2-content">
+          <li><a href="present-simple-i-do-i-dont-do-i.html">Present simple: I do, I don’t, Do I?</a></li>
+          <li><a href="questions-word-order-and-question-words.html">Questions: word order and question words</a></li>
+          <li><a href="adverbs-of-frequency-with-present-simple.html">Adverbs of frequency with present simple</a></li>
+          <li><a href="object-pronouns-vs-subject-pronouns-me-or-i-she-or-her.html">Object pronouns vs. subject pronouns: me or I, she or her?</a></li>
+          <li><a href="whose-possessive-s-whose-is-this-its-mikes.html">Whose, possessive ’s: Whose is this? It’s Mike’s</a></li>
+          <li><a href="at-in-on-prepositions-of-time.html">At, in, on: prepositions of time</a></li>
+          <li><a href="at-in-on-prepositions-of-time.html">At, in, on: prepositions of place</a></li>
+          <li><a href="can-cant-ability-possibility-permission.html">Can, can’t: ability, possibility, permission</a></li>
+        </ul>
+      </div>
+
+      <div class="module" id="module3">
+        <div class="module-header">
+          <h3>Módulo 3 – Desenvolvendo o presente contínuo e imperativos</h3>
+          <button class="module-toggle" data-target="module3-content" aria-expanded="true">Esconder conteúdo</button>
+        </div>
+        <ul class="lesson-links module-content" id="module3-content">
+          <li><a href="present-simple-or-present-continuous.html">Present continuous: I’m doing, I’m not doing, Are you doing?</a></li>
+          <li><a href="present-simple-or-present-continuous.html">Present simple or present continuous?</a></li>
+          <li><a href="the-imperative-sit-down-dont-talk.html">The imperative: Sit down! Don’t talk!</a></li>
+        </ul>
+      </div>
+
+      <div class="module" id="module4">
+        <div class="module-header">
+          <h3>Módulo 4 – Explorando o passado simples</h3>
+          <button class="module-toggle" data-target="module4-content" aria-expanded="true">Esconder conteúdo</button>
+        </div>
+        <ul class="lesson-links module-content" id="module4-content">
+          <li><a href="was-were-past-simple-of-be.html">Was / were: past simple of be</a></li>
+          <li><a href="was-were-past-simple-of-be.html">Past simple: regular / irregular verbs</a></li>
+          <li><a href="was-were-past-simple-of-be.html">Past simple: negatives and questions</a></li>
+          <li><a href="there-is-there-are-there-was-there-were.html">There is, there are / there was, there were</a></li>
+        </ul>
+      </div>
+
+      <div class="module" id="module5">
+        <div class="module-header">
+          <h3>Módulo 5 – Verbos e expressões básicas de quantidade</h3>
+          <button class="module-toggle" data-target="module5-content" aria-expanded="true">Esconder conteúdo</button>
+        </div>
+        <ul class="lesson-links module-content" id="module5-content">
+          <li><a href="../a2-pre-intermediate/gerunds-and-infinitives.html">Verbs + to + infinitive and verbs + -ing</a></li>
+          <li><a href="would-you-like-id-like.html">Would you like…? I’d like…</a></li>
+          <li><a href="have-got.html">Have got</a></li>
+          <li><a href="a-some-any-countable-and-uncountable-nouns.html">A, some, any: countable and uncountable nouns</a></li>
+          <li><a href="../a2-pre-intermediate/quantifiers-much-many-a-lot.html">Much, many, a lot of, a little, a few</a></li>
+          <li><a href="there-or-it.html">There or It</a></li>
+        </ul>
+      </div>
+
+      <div class="module" id="module6">
+        <div class="module-header">
+          <h3>Módulo 6 – Localização e comparação</h3>
+          <button class="module-toggle" data-target="module6-content" aria-expanded="true">Esconder conteúdo</button>
+        </div>
+        <ul class="lesson-links module-content" id="module6-content">
+          <li><a href="at-in-on-prepositions-of-time.html">Next to, under, between, in front of, behind, over, etc.</a></li>
+          <li><a href="comparative-adjectives-older-than-more-important-than-etc.html">Comparative adjectives: older than, more important than, etc.</a></li>
+          <li><a href="comparative-adjectives-older-than-more-important-than-etc.html">Superlative adjectives: the oldest, the most important, etc.</a></li>
+        </ul>
+      </div>
+
+      <div class="module" id="module7">
+        <div class="module-header">
+          <h3>Módulo 7 – Expressando futuro e aprofundando artigos e advérbios</h3>
+          <button class="module-toggle" data-target="module7-content" aria-expanded="true">Esconder conteúdo</button>
+        </div>
+        <ul class="lesson-links module-content" id="module7-content">
+          <li><a href="../a2-pre-intermediate/will-for-promises-predictions.html">Will and shall: future</a></li>
+          <li><a href="be-going-to-plans-and-predictions.html">Be going to: plans and predictions</a></li>
+          <li><a href="../a2-pre-intermediate/adverbs-manner.html">Adverbs of manner (slowly) or adjectives (slow) ?</a></li>
+          <li><a href="a-an-the-no-article-the-use-of-articles-in-english.html">A/an, the, no article: the use of articles in English</a></li>
+          <li><a href="conjunctions-and-but-or-so-because.html">Conjunctions: and, but, or, so, because</a></li>
+          <li><a href="this-that-these-those.html">The difference between “this” and “it”</a></li>
+        </ul>
+      </div>
     </div>
   </main>
 

--- a/script.js
+++ b/script.js
@@ -28,4 +28,18 @@ document.addEventListener('DOMContentLoaded', () => {
     hamb.classList.toggle('open');
   });
 
+  // Module toggle buttons
+  const moduleToggles = document.querySelectorAll('.module-toggle');
+  moduleToggles.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const targetId = btn.getAttribute('data-target');
+      const content = document.getElementById(targetId);
+      if (!content) return;
+      content.classList.toggle('hidden');
+      const hidden = content.classList.contains('hidden');
+      btn.setAttribute('aria-expanded', String(!hidden));
+      btn.textContent = hidden ? 'Mostrar conteúdo' : 'Esconder conteúdo';
+    });
+  });
+
 });

--- a/style.css
+++ b/style.css
@@ -392,3 +392,27 @@ footer {
   font-weight: 700;
   text-align: center;
 }
+
+/* ==== MODULES ==== */
+.module {
+  margin-top: 32px;
+}
+.module-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.module-toggle {
+  background: none;
+  border: 1px solid #3478f6;
+  color: #3478f6;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.module-content {
+  margin-top: 16px;
+}
+.hidden {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- separate the A1 grammar content into modules
- add buttons to hide/show each module
- style the new module sections
- update JS to toggle module visibility

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b380cfe78832382e6805aac0b6f2b