### PR TITLE
Add grammar lesson content

### DIFF
--- a/grammar/a1-elementary/a-an-the-no-article-the-use-of-articles-in-english.html
+++ b/grammar/a1-elementary/a-an-the-no-article-the-use-of-articles-in-english.html
@@ -164,10 +164,64 @@
       <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
     <section id="explanation" class="tab-content active">
-      <p>Conteúdo em breve.
+      <h3>Visão Geral</h3>
+      <p>Em inglês usamos <em>a</em>/<em>an</em> para coisas em geral ou quando mencionamos algo pela primeira vez. Usamos <em>the</em> para coisas específicas ou que já foram mencionadas. Em alguns casos não usamos artigo.</p>
+
+      <h3>A / An</h3>
+      <p>Empregamos <strong>a</strong> antes de palavras que começam com som de consoante e <strong>an</strong> antes de palavras que começam com som de vogal.</p>
+      <div class="example-container">
+        <p>I have <span class="highlight">a</span> cat.<span class="correct"></span></p>
+        <p>She is <span class="highlight">an</span> engineer.<span class="correct"></span></p>
+      </div>
+
+      <h3>The</h3>
+      <p>Usamos <strong>the</strong> quando o ouvinte/leitor sabe exatamente de que coisa estamos falando.</p>
+      <div class="example-container">
+        <p>Close <span class="highlight">the</span> door, please.<span class="correct"></span></p>
+        <p>I liked <span class="highlight">the</span> movie we saw yesterday.<span class="correct"></span></p>
+      </div>
+
+      <h3>No article</h3>
+      <p>Não usamos artigo com nomes próprios, idiomas, refeições ou quando falamos de coisas em geral.</p>
+      <div class="example-container">
+        <p><span class="highlight">Breakfast</span> is ready.<span class="correct"></span></p>
+        <p><span class="highlight">English</span> is difficult for some people.<span class="correct"></span></p>
+      </div>
     </section>
       <section id="exercises" class="tab-content">
-        <p>Exercícios em breve.</p>
+        <h3>Articles in context</h3>
+        <div class="example-container">
+          <p>1. I saw <mark>a</mark> bird outside.</p>
+          <p>2. She wants to buy <mark>an</mark> umbrella.</p>
+          <p>3. Please pass me <mark>the</mark> salt.</p>
+          <p>4. <mark>The</mark> sun is shining today.</p>
+          <p>5. He doesn't eat <mark>breakfast</mark> early.</p>
+          <p>6. <mark>English</mark> is spoken here.</p>
+          <p>7. We live near <mark>the</mark> beach.</p>
+          <p>8. I have <mark>a</mark> new phone.</p>
+          <p>9. She goes to <mark>the</mark> gym on Mondays.</p>
+          <p>10. Do you like <mark>coffee</mark>?</p>
+          <p>11. They visited <mark>the</mark> museum yesterday.</p>
+          <p>12. He is reading <mark>a</mark> magazine.</p>
+          <p>13. Where is <mark>the</mark> station?</p>
+          <p>14. She studies <mark>French</mark> at school.</p>
+          <p>15. Let's watch <mark>a</mark> movie.</p>
+          <p>16. I put <mark>the</mark> keys on the table.</p>
+          <p>17. <mark>Lunch</mark> is at noon.</p>
+          <p>18. <mark>The</mark> children are playing outside.</p>
+          <p>19. He wants to buy <mark>a</mark> house.</p>
+          <p>20. She opened <mark>the</mark> window.</p>
+          <p>21. <mark>Water</mark> boils at 100°C.</p>
+          <p>22. They rode <mark>the</mark> bus to work.</p>
+          <p>23. I need <mark>a</mark> pen.</p>
+          <p>24. <mark>The</mark> flowers are beautiful.</p>
+          <p>25. He speaks <mark>Spanish</mark> fluently.</p>
+          <p>26. She wore <mark>a</mark> red dress.</p>
+          <p>27. We saw <mark>the</mark> Eiffel Tower.</p>
+          <p>28. <mark>Dinner</mark> was delicious.</p>
+          <p>29. Do you have <mark>a</mark> minute?</p>
+          <p>30. I cleaned <mark>the</mark> kitchen.</p>
+        </div>
       </section>
     </div>
   </main>
@@ -189,6 +243,26 @@
           btn.classList.add('active');
           document.getElementById(btn.dataset.tab).classList.add('active');
         });
+      });
+      });
+
+      // Adiciona botões de áudio para cada exemplo
+      document.querySelectorAll('#exercises .example-container p').forEach(p => {
+        const text = p.textContent.trim();
+        const cleanedText = text.replace(/^\d+\.\s*/, '');
+        const btn = document.createElement('button');
+        btn.textContent = '🔊';
+        btn.className = 'tts-btn';
+        btn.type = 'button';
+        btn.addEventListener('click', () => {
+          const utter = new SpeechSynthesisUtterance(cleanedText);
+          utter.lang = 'en-US';
+          utter.rate = 0.8;
+          const voice = speechSynthesis.getVoices().find(v => v.lang === 'en-US' || v.name === 'Google US English');
+          if (voice) utter.voice = voice;
+          speechSynthesis.speak(utter);
+        });
+        p.appendChild(btn);
       });
     });
   </script>

--- a/grammar/a1-elementary/adjectives-old-interesting-expensive-etc.html
+++ b/grammar/a1-elementary/adjectives-old-interesting-expensive-etc.html
@@ -164,10 +164,57 @@
       <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
     <section id="explanation" class="tab-content active">
-      <p>Conteúdo em breve.
+      <h3>Visão Geral</h3>
+      <p>Os adjetivos em inglês são invariáveis: não mudam em número ou gênero. Eles podem vir antes do substantivo ou depois do verbo <em>be</em> e de verbos de ligação como <em>feel</em> ou <em>seem</em>.</p>
+
+      <h3>Antes do substantivo</h3>
+      <p>É muito comum posicionar o adjetivo antes do substantivo que ele descreve.</p>
+      <div class="example-container">
+        <p>It is an <span class="highlight">old</span> house.<span class="correct"></span></p>
+        <p>They have a <span class="highlight">beautiful</span> garden.<span class="correct"></span></p>
+      </div>
+
+      <h3>Depois de verbos como be, feel, seem</h3>
+      <p>Quando usamos verbos de ligação, o adjetivo aparece após o verbo.</p>
+      <div class="example-container">
+        <p>She <span class="highlight">is</span> happy.<span class="correct"></span></p>
+        <p>I <span class="highlight">feel</span> tired.<span class="correct"></span></p>
+      </div>
     </section>
       <section id="exercises" class="tab-content">
-        <p>Exercícios em breve.</p>
+        <h3>Using adjectives</h3>
+        <div class="example-container">
+          <p>1. He has an <mark>old</mark> car.</p>
+          <p>2. This coffee tastes <mark>strong</mark>.</p>
+          <p>3. They live in a <mark>small</mark> town.</p>
+          <p>4. The exam was <mark>difficult</mark>.</p>
+          <p>5. She is very <mark>kind</mark>.</p>
+          <p>6. We bought a <mark>new</mark> computer.</p>
+          <p>7. My bag is <mark>heavy</mark>.</p>
+          <p>8. It seems <mark>easy</mark> to me.</p>
+          <p>9. He is a <mark>good</mark> friend.</p>
+          <p>10. They are <mark>tired</mark> today.</p>
+          <p>11. That was an <mark>interesting</mark> book.</p>
+          <p>12. She wears <mark>expensive</mark> clothes.</p>
+          <p>13. The soup smells <mark>delicious</mark>.</p>
+          <p>14. This exercise is <mark>simple</mark>.</p>
+          <p>15. I like your <mark>new</mark> haircut.</p>
+          <p>16. He gave me a <mark>cheap</mark> watch.</p>
+          <p>17. My parents are <mark>strict</mark>.</p>
+          <p>18. She looks <mark>worried</mark>.</p>
+          <p>19. It's a <mark>cold</mark> morning.</p>
+          <p>20. We had a <mark>fantastic</mark> time.</p>
+          <p>21. This chair is <mark>comfortable</mark>.</p>
+          <p>22. He told a <mark>funny</mark> story.</p>
+          <p>23. The movie was <mark>boring</mark>.</p>
+          <p>24. I am <mark>busy</mark> right now.</p>
+          <p>25. She has <mark>long</mark> hair.</p>
+          <p>26. It was a <mark>hard</mark> decision.</p>
+          <p>27. He owns a <mark>large</mark> company.</p>
+          <p>28. That sounds <mark>strange</mark>.</p>
+          <p>29. What a <mark>beautiful</mark> day!</p>
+          <p>30. The task is <mark>important</mark>.</p>
+        </div>
       </section>
     </div>
   </main>
@@ -189,6 +236,26 @@
           btn.classList.add('active');
           document.getElementById(btn.dataset.tab).classList.add('active');
         });
+      });
+      });
+
+      // Adiciona botões de áudio para cada exemplo
+      document.querySelectorAll('#exercises .example-container p').forEach(p => {
+        const text = p.textContent.trim();
+        const cleanedText = text.replace(/^\d+\.\s*/, '');
+        const btn = document.createElement('button');
+        btn.textContent = '🔊';
+        btn.className = 'tts-btn';
+        btn.type = 'button';
+        btn.addEventListener('click', () => {
+          const utter = new SpeechSynthesisUtterance(cleanedText);
+          utter.lang = 'en-US';
+          utter.rate = 0.8;
+          const voice = speechSynthesis.getVoices().find(v => v.lang === 'en-US' || v.name === 'Google US English');
+          if (voice) utter.voice = voice;
+          speechSynthesis.speak(utter);
+        });
+        p.appendChild(btn);
       });
     });
   </script>

--- a/grammar/a1-elementary/adverbs-of-frequency-with-present-simple.html
+++ b/grammar/a1-elementary/adverbs-of-frequency-with-present-simple.html
@@ -164,10 +164,65 @@
       <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
     <section id="explanation" class="tab-content active">
-      <p>Conteúdo em breve.
+      <h3>Visão Geral</h3>
+      <p>Os advérbios de frequência indicam com que regularidade algo acontece. No presente simples, eles costumam aparecer antes do verbo principal ou após o verbo <em>be</em>.</p>
+
+      <h3>Posição dos advérbios</h3>
+      <p>Com o verbo <em>be</em>, o advérbio vem depois. Com outros verbos, colocamos o advérbio antes do verbo principal.</p>
+      <div class="example-container">
+        <p>She <span class="highlight">is usually</span> at home.<span class="correct"></span></p>
+        <p>They <span class="highlight">often play</span> soccer.<span class="correct"></span></p>
+      </div>
+
+      <h3>Principais advérbios</h3>
+      <table class="simple-table">
+        <thead>
+          <tr><th>Advérbio</th><th>Frequência aproximada</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>always</td><td>100%</td></tr>
+          <tr><td>usually</td><td>80%</td></tr>
+          <tr><td>often</td><td>60%</td></tr>
+          <tr><td>sometimes</td><td>40%</td></tr>
+          <tr><td>rarely</td><td>20%</td></tr>
+          <tr><td>never</td><td>0%</td></tr>
+        </tbody>
+      </table>
     </section>
       <section id="exercises" class="tab-content">
-        <p>Exercícios em breve.</p>
+        <h3>Adverbs of frequency</h3>
+        <div class="example-container">
+          <p>1. I <mark>always</mark> get up early.</p>
+          <p>2. She is <mark>never</mark> late.</p>
+          <p>3. They <mark>often</mark> watch movies.</p>
+          <p>4. He <mark>usually</mark> walks to work.</p>
+          <p>5. We <mark>sometimes</mark> eat out.</p>
+          <p>6. It is <mark>rarely</mark> cold here.</p>
+          <p>7. Do you <mark>often</mark> travel?</p>
+          <p>8. She <mark>always</mark> helps me.</p>
+          <p>9. They are <mark>sometimes</mark> busy.</p>
+          <p>10. He <mark>never</mark> drinks coffee.</p>
+          <p>11. I <mark>usually</mark> read at night.</p>
+          <p>12. We <mark>often</mark> go to the park.</p>
+          <p>13. She is <mark>always</mark> happy.</p>
+          <p>14. They <mark>rarely</mark> cook.</p>
+          <p>15. He <mark>sometimes</mark> plays video games.</p>
+          <p>16. Do you <mark>always</mark> wear a hat?</p>
+          <p>17. The train is <mark>usually</mark> on time.</p>
+          <p>18. I <mark>never</mark> eat meat.</p>
+          <p>19. She <mark>often</mark> reads magazines.</p>
+          <p>20. We are <mark>rarely</mark> tired.</p>
+          <p>21. He <mark>always</mark> arrives early.</p>
+          <p>22. They <mark>sometimes</mark> study together.</p>
+          <p>23. Do you <mark>usually</mark> drive to work?</p>
+          <p>24. She is <mark>never</mark> angry.</p>
+          <p>25. I <mark>often</mark> listen to music.</p>
+          <p>26. He <mark>rarely</mark> watches TV.</p>
+          <p>27. They <mark>always</mark> clean the house.</p>
+          <p>28. We <mark>sometimes</mark> go hiking.</p>
+          <p>29. She <mark>usually</mark> cooks dinner.</p>
+          <p>30. He is <mark>never</mark> bored.</p>
+        </div>
       </section>
     </div>
   </main>
@@ -189,6 +244,26 @@
           btn.classList.add('active');
           document.getElementById(btn.dataset.tab).classList.add('active');
         });
+      });
+      });
+
+      // Adiciona botões de áudio para cada exemplo
+      document.querySelectorAll('#exercises .example-container p').forEach(p => {
+        const text = p.textContent.trim();
+        const cleanedText = text.replace(/^\d+\.\s*/, '');
+        const btn = document.createElement('button');
+        btn.textContent = '🔊';
+        btn.className = 'tts-btn';
+        btn.type = 'button';
+        btn.addEventListener('click', () => {
+          const utter = new SpeechSynthesisUtterance(cleanedText);
+          utter.lang = 'en-US';
+          utter.rate = 0.8;
+          const voice = speechSynthesis.getVoices().find(v => v.lang === 'en-US' || v.name === 'Google US English');
+          if (voice) utter.voice = voice;
+          speechSynthesis.speak(utter);
+        });
+        p.appendChild(btn);
       });
     });
   </script>

--- a/grammar/a1-elementary/present-simple-i-do-i-dont-do-i.html
+++ b/grammar/a1-elementary/present-simple-i-do-i-dont-do-i.html
@@ -164,10 +164,66 @@
       <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
     <section id="explanation" class="tab-content active">
-      <p>Conteúdo em breve.
+      <h3>Visão Geral</h3>
+      <p>O presente simples é usado para fatos habituais e verdades gerais. Para formar perguntas e negativas com a maioria dos verbos, utilizamos <em>do</em> ou <em>does</em>.</p>
+
+      <h3>Form</h3>
+      <table class="simple-table">
+        <thead>
+          <tr>
+            <th>Afirmativa</th>
+            <th>Negativa</th>
+            <th>Interrogativa</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>I/You/We/They <strong>work</strong></td>
+            <td>I/You/We/They <strong>do not</strong> work</td>
+            <td><strong>Do</strong> I/you/we/they work?</td>
+          </tr>
+          <tr>
+            <td>He/She/It <strong>works</strong></td>
+            <td>He/She/It <strong>does not</strong> work</td>
+            <td><strong>Does</strong> he/she/it work?</td>
+          </tr>
+        </tbody>
+      </table>
     </section>
       <section id="exercises" class="tab-content">
-        <p>Exercícios em breve.</p>
+        <h3>Present simple practice</h3>
+        <div class="example-container">
+          <p>1. I <mark>like</mark> coffee.</p>
+          <p>2. She <mark>doesn't like</mark> tea.</p>
+          <p>3. <mark>Do</mark> you play tennis?</p>
+          <p>4. He <mark>works</mark> every day.</p>
+          <p>5. They <mark>don't live</mark> here.</p>
+          <p>6. <mark>Does</mark> she study French?</p>
+          <p>7. We <mark>go</mark> to school by bus.</p>
+          <p>8. I <mark>don't watch</mark> TV.</p>
+          <p>9. <mark>Do</mark> they know your name?</p>
+          <p>10. He <mark>doesn't work</mark> on Sundays.</p>
+          <p>11. She <mark>plays</mark> the guitar.</p>
+          <p>12. <mark>Do</mark> you read books?</p>
+          <p>13. I <mark>study</mark> every night.</p>
+          <p>14. They <mark>don't eat</mark> meat.</p>
+          <p>15. <mark>Does</mark> he like soccer?</p>
+          <p>16. We <mark>start</mark> work at nine.</p>
+          <p>17. She <mark>doesn't drive</mark>.</p>
+          <p>18. <mark>Do</mark> I need a ticket?</p>
+          <p>19. He <mark>visits</mark> his parents often.</p>
+          <p>20. They <mark>don't speak</mark> Italian.</p>
+          <p>21. <mark>Does</mark> it rain here a lot?</p>
+          <p>22. You <mark>work</mark> very hard.</p>
+          <p>23. She <mark>goes</mark> to the gym.</p>
+          <p>24. <mark>Do</mark> we need passports?</p>
+          <p>25. He <mark>doesn't understand</mark>.</p>
+          <p>26. I <mark>drink</mark> water every day.</p>
+          <p>27. They <mark>study</mark> English.</p>
+          <p>28. She <mark>doesn't work</mark> here.</p>
+          <p>29. <mark>Do</mark> you like music?</p>
+          <p>30. We <mark>don't have</mark> a car.</p>
+        </div>
       </section>
     </div>
   </main>
@@ -189,6 +245,26 @@
           btn.classList.add('active');
           document.getElementById(btn.dataset.tab).classList.add('active');
         });
+      });
+      });
+
+      // Adiciona botões de áudio para cada exemplo
+      document.querySelectorAll('#exercises .example-container p').forEach(p => {
+        const text = p.textContent.trim();
+        const cleanedText = text.replace(/^\d+\.\s*/, '');
+        const btn = document.createElement('button');
+        btn.textContent = '🔊';
+        btn.className = 'tts-btn';
+        btn.type = 'button';
+        btn.addEventListener('click', () => {
+          const utter = new SpeechSynthesisUtterance(cleanedText);
+          utter.lang = 'en-US';
+          utter.rate = 0.8;
+          const voice = speechSynthesis.getVoices().find(v => v.lang === 'en-US' || v.name === 'Google US English');
+          if (voice) utter.voice = voice;
+          speechSynthesis.speak(utter);
+        });
+        p.appendChild(btn);
       });
     });
   </script>

--- a/grammar/a1-elementary/questions-word-order-and-question-words.html
+++ b/grammar/a1-elementary/questions-word-order-and-question-words.html
@@ -164,10 +164,57 @@
       <button class="tab-button" data-tab="exercises">Examples</button>
     </div>
     <section id="explanation" class="tab-content active">
-      <p>Conteúdo em breve.
+      <h3>Visão Geral</h3>
+      <p>As perguntas em inglês costumam seguir a ordem auxiliar + sujeito + verbo principal. Quando usamos <em>question words</em> (what, where, when, etc.), elas aparecem no início da pergunta.</p>
+
+      <h3>Yes/No questions</h3>
+      <p>Nesse tipo de pergunta, usamos somente o auxiliar antes do sujeito.</p>
+      <div class="example-container">
+        <p><span class="highlight">Do</span> you like pizza?<span class="correct"></span></p>
+        <p><span class="highlight">Is</span> she at home?<span class="correct"></span></p>
+      </div>
+
+      <h3>Wh- questions</h3>
+      <p>Quando adicionamos palavras interrogativas, elas vêm antes do auxiliar.</p>
+      <div class="example-container">
+        <p><span class="highlight">Where</span> do you live?<span class="correct"></span></p>
+        <p><span class="highlight">When</span> does the film start?<span class="correct"></span></p>
+      </div>
     </section>
       <section id="exercises" class="tab-content">
-        <p>Exercícios em breve.</p>
+        <h3>Question practice</h3>
+        <div class="example-container">
+          <p>1. <mark>Do</mark> you work here?</p>
+          <p>2. <mark>Where</mark> do they live?</p>
+          <p>3. <mark>Is</mark> he your brother?</p>
+          <p>4. <mark>When</mark> does class begin?</p>
+          <p>5. <mark>Does</mark> she like ice cream?</p>
+          <p>6. <mark>What</mark> do you need?</p>
+          <p>7. <mark>Are</mark> we late?</p>
+          <p>8. <mark>How</mark> do you spell that?</p>
+          <p>9. <mark>Does</mark> it rain a lot?</p>
+          <p>10. <mark>Who</mark> is your teacher?</p>
+          <p>11. <mark>Do</mark> they know the answer?</p>
+          <p>12. <mark>Why</mark> are you sad?</p>
+          <p>13. <mark>Is</mark> this your pen?</p>
+          <p>14. <mark>Where</mark> is the station?</p>
+          <p>15. <mark>Do</mark> we need tickets?</p>
+          <p>16. <mark>What</mark> does he want?</p>
+          <p>17. <mark>Are</mark> you free tomorrow?</p>
+          <p>18. <mark>When</mark> do you get up?</p>
+          <p>19. <mark>Does</mark> she have siblings?</p>
+          <p>20. <mark>How</mark> old is he?</p>
+          <p>21. <mark>Do</mark> I look okay?</p>
+          <p>22. <mark>Where</mark> are my keys?</p>
+          <p>23. <mark>Is</mark> it far from here?</p>
+          <p>24. <mark>What</mark> time is it?</p>
+          <p>25. <mark>Do</mark> you need help?</p>
+          <p>26. <mark>Who</mark> lives there?</p>
+          <p>27. <mark>Are</mark> they students?</p>
+          <p>28. <mark>Why</mark> does he study English?</p>
+          <p>29. <mark>Does</mark> the shop open early?</p>
+          <p>30. <mark>When</mark> is your birthday?</p>
+        </div>
       </section>
     </div>
   </main>
@@ -189,6 +236,26 @@
           btn.classList.add('active');
           document.getElementById(btn.dataset.tab).classList.add('active');
         });
+      });
+      });
+
+      // Adiciona botões de áudio para cada exemplo
+      document.querySelectorAll('#exercises .example-container p').forEach(p => {
+        const text = p.textContent.trim();
+        const cleanedText = text.replace(/^\d+\.\s*/, '');
+        const btn = document.createElement('button');
+        btn.textContent = '🔊';
+        btn.className = 'tts-btn';
+        btn.type = 'button';
+        btn.addEventListener('click', () => {
+          const utter = new SpeechSynthesisUtterance(cleanedText);
+          utter.lang = 'en-US';
+          utter.rate = 0.8;
+          const voice = speechSynthesis.getVoices().find(v => v.lang === 'en-US' || v.name === 'Google US English');
+          if (voice) utter.voice = voice;
+          speechSynthesis.speak(utter);
+        });
+        p.appendChild(btn);
       });
     });
   </script>


### PR DESCRIPTION
## Summary
- fill in articles, adjectives, present simple, questions and adverbs pages with explanations and examples
- enable text-to-speech buttons in those lessons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b3f6aeec08323aafdf513e3e146fa